### PR TITLE
Migrate to TypeScript 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@
 /typings
 .baseDir.ts
 .tscache
+.tsconfig*.json
 coverage-unmapped.json
 npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
   directories:
   - node_modules
 install:
-- "travis_retry npm install grunt-cli $(node -e \"var deps = require('./package.json').peerDependencies; for(var name in deps) process.stdout.write(name + '@' + deps[name] + ' ');\")"
+- travis_retry npm install grunt-cli
 - travis_retry npm install
 script:
 - grunt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-- '5.1'
+- '6'
 env:
   global:
   - BROWSERSTACK_USERNAME: dtktestaccount1

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/dojo/dataviz.git"
   },
   "scripts": {
-    "prepublish": "grunt dist",
+    "prepublish": "grunt peerDepInstall dist",
     "test": "grunt test"
   },
   "typings": "./dist/umd/dojo-dataviz.d.ts",
@@ -42,7 +42,7 @@
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-watch": "^1.0.0",
-    "grunt-dojo2": ">=2.0.0-beta.7",
+    "grunt-dojo2": ">=2.0.0-beta.13",
     "grunt-text-replace": "^0.4.0",
     "grunt-ts": "^5.5.1",
     "grunt-tslint": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
   "typings": "./dist/umd/dojo-dataviz.d.ts",
   "peerDependencies": {
     "@reactivex/rxjs": "5.0.0-beta.6",
-    "dojo-compose": ">=2.0.0-beta.5",
-    "dojo-core": ">=2.0.0-alpha.7",
-    "dojo-has": "^2.0.0-alpha.1",
-    "dojo-shim": "^2.0.0-alpha.1",
-    "dojo-widgets": "^2.0.0-alpha.3",
+    "dojo-compose": "next",
+    "dojo-core": "next",
+    "dojo-has": "next",
+    "dojo-shim": "next",
+    "dojo-widgets": "next",
     "immutable": "^3.7.6",
     "maquette": "^2.3.1"
   },
@@ -50,7 +50,7 @@
     "intern": "^3.2.3",
     "istanbul": "^0.4.3",
     "remap-istanbul": "^0.6.4",
-    "tslint": "^3.11.0",
-    "typescript": "^1.8.10"
+    "tslint": "next",
+    "typescript": "next"
   }
 }

--- a/src/render/createChart.ts
+++ b/src/render/createChart.ts
@@ -65,43 +65,38 @@ const createChart: ChartFactory = createWidget
 	.mixin({
 		aspectAdvice: {
 			before: {
-				getNodeAttributes(overrides?: VNodeProperties): VNodeProperties[] {
-					const chart: Chart<ChartState> = this;
-					return [assign(chart.getRootAttributes(), overrides)];
+				getNodeAttributes(this: Chart<ChartState>, overrides?: VNodeProperties): VNodeProperties[] {
+					return [assign(this.getRootAttributes(), overrides)];
 				}
 			}
 		},
 
 		mixin: <ChartMixin> {
-			get xInset() {
-				const chart: Chart<ChartState> = this;
-				const { xInset = shadowXInsets.get(chart) } = chart.state || {};
+			get xInset(this: Chart<ChartState>) {
+				const { xInset = shadowXInsets.get(this) } = this.state || {};
 				return xInset;
 			},
 
 			set xInset(xInset) {
-				const chart: Chart<ChartState> = this;
-				if (chart.state) {
-					chart.setState({ xInset });
+				if (this.state) {
+					this.setState({ xInset });
 				}
 				else {
-					shadowXInsets.set(chart, xInset);
+					shadowXInsets.set(this, xInset);
 				}
 			},
 
-			get yInset() {
-				const chart: Chart<ChartState> = this;
-				const { yInset = shadowYInsets.get(chart) } = chart.state || {};
+			get yInset(this: Chart<ChartState>) {
+				const { yInset = shadowYInsets.get(this) } = this.state || {};
 				return yInset;
 			},
 
 			set yInset(yInset) {
-				const chart: Chart<ChartState> = this;
-				if (chart.state) {
-					chart.setState({ yInset });
+				if (this.state) {
+					this.setState({ yInset });
 				}
 				else {
-					shadowYInsets.set(chart, yInset);
+					shadowYInsets.set(this, yInset);
 				}
 			},
 

--- a/src/render/createColumnChart.ts
+++ b/src/render/createColumnChart.ts
@@ -42,17 +42,16 @@ const createColumnChart: GenericColumnChartFactory<any> = createChart
 	.mixin(createAxes)
 	.mixin(createColumnPlot)
 	.extend({
-		getChildrenNodes(): VNode[] {
-			const chart: ColumnChart<any, any, any> = this;
-			const plot = chart.plot();
+		getChildrenNodes(this: ColumnChart<any, any, any>): VNode[] {
+			const plot = this.plot();
 			if (plot.points.length === 0) {
 				return [];
 			}
 
-			const { domain, xInset, yInset } = chart;
+			const { domain, xInset, yInset } = this;
 			const nodes: VNode[] = [];
 
-			const axes = chart.createAxes(plot, domain);
+			const axes = this.createAxes(plot, domain);
 			let { height: chartHeight, width: chartWidth } = plot;
 			chartWidth += axes.extraWidth;
 			chartHeight += axes.extraHeight;
@@ -85,7 +84,7 @@ const createColumnChart: GenericColumnChartFactory<any> = createChart
 			nodes.push(h('g', {
 				key: 'plot',
 				'transform': `translate(${xInset} ${yInset + axes.extraHeight})`
-			}, chart.renderPlotPoints(plot.points)));
+			}, this.renderPlotPoints(plot.points)));
 
 			return nodes;
 		}

--- a/src/render/createGroupedColumnChart.ts
+++ b/src/render/createGroupedColumnChart.ts
@@ -94,38 +94,38 @@ const shadowGroupSpacings = new WeakMap<GroupedColumnChart<any, any, any, Groupe
 const createGroupedColumnChart: GenericGroupedColumnChartFactory<any, any> = createColumnChart
 	.mixin({
 		mixin: {
-			get groupSpacing() {
-				const chart: GroupedColumnChart<any, any, any, GroupedColumnChartState<any, any>> = this;
-				const { groupSpacing = shadowGroupSpacings.get(chart) } = chart.state || {};
+			get groupSpacing(this: GroupedColumnChart<any, any, any, GroupedColumnChartState<any, any>>) {
+				const { groupSpacing = shadowGroupSpacings.get(this) } = this.state || {};
 				return groupSpacing;
 			},
 
 			set groupSpacing(groupSpacing) {
-				const chart: GroupedColumnChart<any, any, any, GroupedColumnChartState<any, any>> = this;
-				if (chart.state) {
-					chart.setState({ groupSpacing });
+				if (this.state) {
+					this.setState({ groupSpacing });
 				}
 				else {
-					shadowGroupSpacings.set(chart, groupSpacing);
+					shadowGroupSpacings.set(this, groupSpacing);
 				}
-				chart.invalidate();
+				this.invalidate();
 			}
 		},
 
 		aspectAdvice: {
 			after: {
-				plot<G, T>({
-					height,
-					horizontalValues,
-					points: columnPoints,
-					verticalValues,
-					width,
-					zero
-				}: ColumnPointPlot<T>): GroupedColumnPointPlot<G, T> {
-					const chart: GroupedColumnChart<G, T, GroupedColumn<G, T>, GroupedColumnChartState<T, GroupedColumn<G, T>>> = this;
-					const { columnHeight, columnSpacing, groupSpacing } = chart;
+				plot<G, T>(
+					this: GroupedColumnChart<G, T, GroupedColumn<G, T>, GroupedColumnChartState<T, GroupedColumn<G, T>>>,
+					{
+						height,
+						horizontalValues,
+						points: columnPoints,
+						verticalValues,
+						width,
+						zero
+					}: ColumnPointPlot<T>
+				): GroupedColumnPointPlot<G, T> {
+					const { columnHeight, columnSpacing, groupSpacing } = this;
 
-					const groupSelector = groupSelectors.get(chart);
+					const groupSelector = groupSelectors.get(this);
 					interface Record {
 						columnPoints: ColumnPoint<T>[];
 						columns: Column<T>[];
@@ -204,7 +204,7 @@ const createGroupedColumnChart: GenericGroupedColumnChartFactory<any, any> = cre
 
 			around: {
 				renderPlotPoints<G, T>(renderColumns: (points: ColumnPoint<T>[]) => VNode[]) {
-					return (groupPoints: GroupedColumnPoint<G, T>[]) => {
+					return function(this: any, groupPoints: GroupedColumnPoint<G, T>[]) {
 						return groupPoints.map(({ columnPoints, datum }) => {
 							const props: VNodeProperties = {
 								key: datum.input

--- a/src/render/createGroupedColumnChart.ts
+++ b/src/render/createGroupedColumnChart.ts
@@ -163,9 +163,11 @@ const createGroupedColumnChart: GenericGroupedColumnChartFactory<any, any> = cre
 					}
 
 					let chartWidth = 0;
-					// Workaround for bad from() typing <https://github.com/dojo/shim/issues/3>
-					const points = from<GroupedColumnPoint<G, T>>(<any> groups, (entry: any, index: number) => {
-						const [group, { columnPoints, columns, totalValue, value, y1 }] = <[G, Record]> entry;
+					const points = from<
+						[G, Record],
+						GroupedColumnPoint<G, T>
+					>(groups.entries(), (entry, index) => {
+						const [group, { columnPoints, columns, totalValue, value, y1 }] = entry;
 
 						const x1 = chartWidth;
 

--- a/src/render/createStackedColumnChart.ts
+++ b/src/render/createStackedColumnChart.ts
@@ -87,49 +87,49 @@ const shadowStackSpacings = new WeakMap<StackedColumnChart<any, any, any, Stacke
 const createStackedColumnChart: GenericStackedColumnChartFactory<any, any> = createColumnChart
 	.mixin({
 		mixin: {
-			get stackSpacing() {
-				const chart: StackedColumnChart<any, any, any, StackedColumnChartState<any, any>> = this;
-				const { stackSpacing = shadowStackSpacings.get(chart) } = chart.state || {};
+			get stackSpacing(this: StackedColumnChart<any, any, any, StackedColumnChartState<any, any>>) {
+				const { stackSpacing = shadowStackSpacings.get(this) } = this.state || {};
 				return stackSpacing;
 			},
 
 			set stackSpacing(stackSpacing) {
-				const chart: StackedColumnChart<any, any, any, StackedColumnChartState<any, any>> = this;
-				if (chart.state) {
-					chart.setState({ stackSpacing });
+				if (this.state) {
+					this.setState({ stackSpacing });
 				}
 				else {
-					shadowStackSpacings.set(chart, stackSpacing);
+					shadowStackSpacings.set(this, stackSpacing);
 				}
-				chart.invalidate();
+				this.invalidate();
 			}
 		},
 
 		aspectAdvice: {
 			after: {
-				plot<G, T>({
-					height,
-					horizontalValues,
-					points: columnPoints,
-					verticalValues,
-					width,
-					zero
-				}: ColumnPointPlot<T>): StackedColumnPointPlot<G, T> {
-					const chart: StackedColumnChart<G, T, StackedColumn<G, T>, StackedColumnChartState<T, StackedColumn<G, T>>> = this;
+				plot<G, T>(
+					this: StackedColumnChart<G, T, StackedColumn<G, T>, StackedColumnChartState<T, StackedColumn<G, T>>>,
+					{
+						height,
+						horizontalValues,
+						points: columnPoints,
+						verticalValues,
+						width,
+						zero
+					}: ColumnPointPlot<T>
+				): StackedColumnPointPlot<G, T> {
 					const {
 						columnHeight,
 						columnSpacing,
 						columnWidth,
 						domain: [domainMin, domainMax],
 						stackSpacing
-					} = chart;
+					} = this;
 
 					let mostNegativeRelValue = 0;
 					let mostNegativeValue = 0;
 					let mostPositiveRelValue = 0;
 					let mostPositiveValue = 0;
 
-					const stackSelector = stackSelectors.get(chart);
+					const stackSelector = stackSelectors.get(this);
 					interface Record {
 						columnPoints: ColumnPoint<T>[];
 						columns: Column<T>[];
@@ -345,7 +345,7 @@ const createStackedColumnChart: GenericStackedColumnChartFactory<any, any> = cre
 
 			around: {
 				renderPlotPoints<G, T>(renderColumns: (points: ColumnPoint<T>[]) => VNode[]) {
-					return (stackPoints: StackedColumnPoint<G, T>[]) => {
+					return function(this: any, stackPoints: StackedColumnPoint<G, T>[]) {
 						return stackPoints.map(({ columnPoints, datum }) => {
 							const props: VNodeProperties = {
 								key: datum.input

--- a/src/render/createStackedColumnChart.ts
+++ b/src/render/createStackedColumnChart.ts
@@ -248,8 +248,10 @@ const createStackedColumnChart: GenericStackedColumnChartFactory<any, any> = cre
 					const negativeOffset = positiveHeight + 1;
 
 					let chartWidth = 0;
-					// Workaround for bad from() typing <https://github.com/dojo/shim/issues/3>
-					const points = from<StackedColumnPoint<G, T>>(<any> stacks, (entry: any, index: number) => {
+					const points = from<
+						[G, [Record, Record]],
+						StackedColumnPoint<G, T>
+					>(stacks.entries(), (entry, index) => {
 						const [stack, signed] = <[G, [Record, Record]]> entry;
 
 						const value = signed[0].value + signed[1].value;

--- a/src/render/mixins/createAxesMixin.ts
+++ b/src/render/mixins/createAxesMixin.ts
@@ -342,53 +342,44 @@ interface AxesConfiguration<D> {
 const shadowConfiguration = new WeakMap<Axes<any>, AxesConfiguration<any>>();
 
 const createAxes: AxesFactory<any> = compose(<AxesMixin<any>> {
-	get bottomAxis() {
-		const axes: Axes<any> = this;
-		return shadowConfiguration.get(axes).bottom;
+	get bottomAxis(this: Axes<any>) {
+		return shadowConfiguration.get(this).bottom;
 	},
 
 	set bottomAxis(axis: AxisConfiguration<any>) {
-		const axes: Axes<any> = this;
-		shadowConfiguration.get(axes).bottom = axis;
-		axes.invalidate();
+		shadowConfiguration.get(this).bottom = axis;
+		this.invalidate();
 	},
 
-	get leftAxis() {
-		const axes: Axes<any> = this;
-		return shadowConfiguration.get(axes).left;
+	get leftAxis(this: Axes<any>) {
+		return shadowConfiguration.get(this).left;
 	},
 
 	set leftAxis(axis: AxisConfiguration<any>) {
-		const axes: Axes<any> = this;
-		shadowConfiguration.get(axes).left = axis;
-		axes.invalidate();
+		shadowConfiguration.get(this).left = axis;
+		this.invalidate();
 	},
 
-	get rightAxis() {
-		const axes: Axes<any> = this;
-		return shadowConfiguration.get(axes).right;
+	get rightAxis(this: Axes<any>) {
+		return shadowConfiguration.get(this).right;
 	},
 
 	set rightAxis(axis: AxisConfiguration<any>) {
-		const axes: Axes<any> = this;
-		shadowConfiguration.get(axes).right = axis;
-		axes.invalidate();
+		shadowConfiguration.get(this).right = axis;
+		this.invalidate();
 	},
 
-	get topAxis() {
-		const axes: Axes<any> = this;
-		return shadowConfiguration.get(axes).top;
+	get topAxis(this: Axes<any>) {
+		return shadowConfiguration.get(this).top;
 	},
 
 	set topAxis(axis: AxisConfiguration<any>) {
-		const axes: Axes<any> = this;
-		shadowConfiguration.get(axes).top = axis;
-		axes.invalidate();
+		shadowConfiguration.get(this).top = axis;
+		this.invalidate();
 	},
 
-	createAxes<D extends Datum<any>>(plot: Plot<Point<D>>, domain: Domain): CreatedAxes {
-		const axes: Axes<D> = this;
-		const configuration = shadowConfiguration.get(axes);
+	createAxes<D extends Datum<any>>(this: Axes<D>, plot: Plot<Point<D>>, domain: Domain): CreatedAxes {
+		const configuration = shadowConfiguration.get(this);
 
 		const result: CreatedAxes = {
 			extraHeight: 0,
@@ -396,22 +387,22 @@ const createAxes: AxesFactory<any> = compose(<AxesMixin<any>> {
 		};
 
 		if (configuration.bottom) {
-			const [nodes, extra] = axes.createAxis(configuration.bottom, 'bottom', plot, domain);
+			const [nodes, extra] = this.createAxis(configuration.bottom, 'bottom', plot, domain);
 			result.bottom = nodes;
 			result.extraWidth = Math.max(result.extraWidth, extra);
 		}
 		if (configuration.left) {
-			const [nodes, extra] = axes.createAxis(configuration.left, 'left', plot, domain);
+			const [nodes, extra] = this.createAxis(configuration.left, 'left', plot, domain);
 			result.left = nodes;
 			result.extraHeight = Math.max(result.extraHeight, extra);
 		}
 		if (configuration.right) {
-			const [nodes, extra] = axes.createAxis(configuration.right, 'right', plot, domain);
+			const [nodes, extra] = this.createAxis(configuration.right, 'right', plot, domain);
 			result.right = nodes;
 			result.extraHeight = Math.max(result.extraHeight, extra);
 		}
 		if (configuration.top) {
-			const [nodes, extra] = axes.createAxis(configuration.top, 'top', plot, domain);
+			const [nodes, extra] = this.createAxis(configuration.top, 'top', plot, domain);
 			result.top = nodes;
 			result.extraWidth = Math.max(result.extraWidth, extra);
 		}
@@ -419,12 +410,12 @@ const createAxes: AxesFactory<any> = compose(<AxesMixin<any>> {
 	},
 
 	createAxis<D extends Datum<any>>(
+		this: Axes<D>,
 		cfg: AxisConfiguration<D>,
 		side: Side,
 		plot: Plot<Point<D>>,
 		domain: Domain
 	): [VNode[], number] {
-		const axes: Axes<D> = this;
 		const { gridLines, ticks } = cfg;
 		const { height, width, zero } = plot;
 
@@ -452,31 +443,31 @@ const createAxes: AxesFactory<any> = compose(<AxesMixin<any>> {
 
 		if (ticks && ticks.zeroth) {
 			if (isHorizontal) {
-				nodes.push(axes.createAxisTick(ticks, side, 0, 0));
+				nodes.push(this.createAxisTick(ticks, side, 0, 0));
 			}
 			else {
-				nodes.push(axes.createAxisTick(ticks, side, 0, zero.y));
+				nodes.push(this.createAxisTick(ticks, side, 0, zero.y));
 			}
 		}
 
 		if (typeof gridLines === 'object' && gridLines.zeroth) {
 			if (isHorizontal) {
-				nodes.push(axes.createAxisGridLine(gridLineLength, side, 0, 0, 0));
+				nodes.push(this.createAxisGridLine(gridLineLength, side, 0, 0, 0));
 			}
 			else {
-				nodes.push(axes.createAxisGridLine(gridLineLength, side, 0, 0, zero.y));
+				nodes.push(this.createAxisGridLine(gridLineLength, side, 0, 0, zero.y));
 			}
 		}
 
 		if (isHardcoded(cfg)) {
-			nodes.push(...axes.createHardcodedAxis(cfg, labels, ticks, gridLineLength, side, plot));
+			nodes.push(...this.createHardcodedAxis(cfg, labels, ticks, gridLineLength, side, plot));
 		}
 		else if (isInputBased(cfg)) {
-			nodes.push(...axes.createInputBasedAxis(cfg, labels, ticks, gridLineLength, side, plot));
+			nodes.push(...this.createInputBasedAxis(cfg, labels, ticks, gridLineLength, side, plot));
 		}
 		else if (isRangeBased(cfg)) {
 			let stepNodes: VNode[];
-			[stepNodes, extraSpace] = axes.createRangeBasedAxis(cfg, labels, ticks, gridLineLength, side, plot, domain);
+			[stepNodes, extraSpace] = this.createRangeBasedAxis(cfg, labels, ticks, gridLineLength, side, plot, domain);
 			nodes.push(...stepNodes);
 		}
 
@@ -651,6 +642,7 @@ const createAxes: AxesFactory<any> = compose(<AxesMixin<any>> {
 	},
 
 	createHardcodedAxis(
+		this: Axes<any>,
 		{ hardcoded }: HardcodedAxis,
 		labels: LabelConfiguration,
 		ticks: TickConfiguration,
@@ -658,8 +650,6 @@ const createAxes: AxesFactory<any> = compose(<AxesMixin<any>> {
 		side: Side,
 		{ height, width }: Plot<any>
 	) {
-		const axes: Axes<any> = this;
-
 		const isHorizontal = side === 'bottom' || side === 'top';
 		const nodes: VNode[] = [];
 
@@ -684,17 +674,17 @@ const createAxes: AxesFactory<any> = compose(<AxesMixin<any>> {
 			// FIXME: Don't repeat zeroth tick
 			if (ticks) {
 				const p = isHorizontal ? x : y;
-				nodes.push(axes.createAxisTick(ticks, side, index, p));
+				nodes.push(this.createAxisTick(ticks, side, index, p));
 			}
 			// FIXME: Don't repeat zeroth grid line
 			if (gridLineLength) {
-				nodes.push(axes.createAxisGridLine(gridLineLength, side, index, x, y));
+				nodes.push(this.createAxisGridLine(gridLineLength, side, index, x, y));
 			}
 
 			if (labels && text !== '') {
 				const p1 = isHorizontal ? x : y;
 				const p2 = prev;
-				nodes.push(axes.createAxisLabel(labels, text, side, index, p1, p2, false, ticks));
+				nodes.push(this.createAxisLabel(labels, text, side, index, p1, p2, false, ticks));
 			}
 
 			index++;
@@ -705,6 +695,7 @@ const createAxes: AxesFactory<any> = compose(<AxesMixin<any>> {
 	},
 
 	createInputBasedAxis<D extends Datum<any>>(
+		this: Axes<D>,
 		{ inputs }: InputBasedAxis<D>,
 		labels: LabelConfiguration,
 		ticks: TickConfiguration,
@@ -712,7 +703,6 @@ const createAxes: AxesFactory<any> = compose(<AxesMixin<any>> {
 		side: Side,
 		{ points, zero }: Plot<Point<D>>
 	) {
-		const axes: Axes<D> = this;
 		const labelSelector = typeof inputs === 'boolean' ? null : inputs.labelSelector;
 
 		const isHorizontal = side === 'bottom' || side === 'top';
@@ -729,20 +719,20 @@ const createAxes: AxesFactory<any> = compose(<AxesMixin<any>> {
 			if (ticks || gridLineLength) {
 				// FIXME: Don't repeat zeroth tick
 				if (ticks) {
-					nodes.push(axes.createAxisTick(ticks, side, index, p1, p2, isNegative));
+					nodes.push(this.createAxisTick(ticks, side, index, p1, p2, isNegative));
 				}
 				// FIXME: Don't repeat zeroth grid line
 				if (gridLineLength) {
 					const x = isHorizontal ? x2 : 0;
 					const y = isHorizontal ? 0 : y1;
-					nodes.push(axes.createAxisGridLine(gridLineLength, side, index, x, y));
+					nodes.push(this.createAxisGridLine(gridLineLength, side, index, x, y));
 				}
 			}
 
 			if (labels && labelSelector) {
 				const text = labelSelector(datum);
 				if (text !== '') {
-					nodes.push(axes.createAxisLabel(labels, text, side, index, p1, p2, isNegative, ticks));
+					nodes.push(this.createAxisLabel(labels, text, side, index, p1, p2, isNegative, ticks));
 				}
 			}
 		}
@@ -751,6 +741,7 @@ const createAxes: AxesFactory<any> = compose(<AxesMixin<any>> {
 	},
 
 	createRangeBasedAxis<D extends Datum<any>>(
+		this: Axes<D>,
 		{ range }: RangeBasedAxis,
 		labels: LabelConfiguration,
 		ticks: TickConfiguration,
@@ -766,7 +757,6 @@ const createAxes: AxesFactory<any> = compose(<AxesMixin<any>> {
 		}: Plot<Point<D>>,
 		[domainMin, domainMax]: Domain
 	) {
-		const axes: Axes<D> = this;
 		const {
 			fixed = false,
 			labelSelector
@@ -828,18 +818,18 @@ const createAxes: AxesFactory<any> = compose(<AxesMixin<any>> {
 
 			// FIXME: Don't repeat zeroth tick
 			if (ticks) {
-				nodes.push(axes.createAxisTick(ticks, side, index, p));
+				nodes.push(this.createAxisTick(ticks, side, index, p));
 			}
 			// FIXME: Don't duplicate zeroth gridline
 			if (gridLineLength) {
-				nodes.push(axes.createAxisGridLine(gridLineLength, side, index, x, y));
+				nodes.push(this.createAxisGridLine(gridLineLength, side, index, x, y));
 			}
 
 			const text = labelSelector ? labelSelector(step) : String(step);
 			if (labels && text !== '') {
 				const p1 = isNegative ? prev : p;
 				const p2 = isNegative ? p : prev;
-				nodes.push(axes.createAxisLabel(labels, text, side, index, p1, p2, isNegative, ticks));
+				nodes.push(this.createAxisLabel(labels, text, side, index, p1, p2, isNegative, ticks));
 			}
 
 			index++;

--- a/src/render/mixins/createColumnPlotMixin.ts
+++ b/src/render/mixins/createColumnPlotMixin.ts
@@ -172,78 +172,69 @@ const shadowColumnWidths = new WeakMap<ColumnPlot<any, ColumnPlotState<any>>, nu
 const shadowDomains = new WeakMap<ColumnPlot<any, ColumnPlotState<any>>, Domain>();
 
 const createColumnPlot: ColumnPlotFactory<any> = compose({
-	get columnHeight() {
-		const plot: ColumnPlot<any, ColumnPlotState<any>> = this;
-		const { columnHeight = shadowColumnHeights.get(plot) } = plot.state || {};
+	get columnHeight(this: ColumnPlot<any, ColumnPlotState<any>>) {
+		const { columnHeight = shadowColumnHeights.get(this) } = this.state || {};
 		return columnHeight;
 	},
 
 	set columnHeight(columnHeight) {
-		const plot: ColumnPlot<any, ColumnPlotState<any>> = this;
-		if (plot.state) {
-			plot.setState({ columnHeight });
+		if (this.state) {
+			this.setState({ columnHeight });
 		}
 		else {
-			shadowColumnHeights.set(plot, columnHeight);
+			shadowColumnHeights.set(this, columnHeight);
 		}
-		plot.invalidate();
+		this.invalidate();
 	},
 
-	get columnSpacing() {
-		const plot: ColumnPlot<any, ColumnPlotState<any>> = this;
-		const { columnSpacing = shadowColumnSpacings.get(plot) } = plot.state || {};
+	get columnSpacing(this: ColumnPlot<any, ColumnPlotState<any>>) {
+		const { columnSpacing = shadowColumnSpacings.get(this) } = this.state || {};
 		return columnSpacing;
 	},
 
 	set columnSpacing(columnSpacing) {
-		const plot: ColumnPlot<any, ColumnPlotState<any>> = this;
-		if (plot.state) {
-			plot.setState({ columnSpacing });
+		if (this.state) {
+			this.setState({ columnSpacing });
 		}
 		else {
-			shadowColumnSpacings.set(plot, columnSpacing);
+			shadowColumnSpacings.set(this, columnSpacing);
 		}
-		plot.invalidate();
+		this.invalidate();
 	},
 
-	get columnWidth() {
-		const plot: ColumnPlot<any, ColumnPlotState<any>> = this;
-		const { columnWidth = shadowColumnWidths.get(plot) } = plot.state || {};
+	get columnWidth(this: ColumnPlot<any, ColumnPlotState<any>>) {
+		const { columnWidth = shadowColumnWidths.get(this) } = this.state || {};
 		return columnWidth;
 	},
 
 	set columnWidth(columnWidth) {
-		const plot: ColumnPlot<any, ColumnPlotState<any>> = this;
-		if (plot.state) {
-			plot.setState({ columnWidth });
+		if (this.state) {
+			this.setState({ columnWidth });
 		}
 		else {
-			shadowColumnWidths.set(plot, columnWidth);
+			shadowColumnWidths.set(this, columnWidth);
 		}
-		plot.invalidate();
+		this.invalidate();
 	},
 
-	get domain() {
-		const plot: ColumnPlot<any, ColumnPlotState<any>> = this;
-		const { domain = shadowDomains.get(plot) } = plot.state || {};
+	get domain(this: ColumnPlot<any, ColumnPlotState<any>>) {
+		const { domain = shadowDomains.get(this) } = this.state || {};
 		return normalizeDomain(domain);
 	},
 
 	set domain(domain) {
-		const plot: ColumnPlot<any, ColumnPlotState<any>> = this;
-		if (plot.state) {
-			plot.setState({ domain });
+		if (this.state) {
+			this.setState({ domain });
 		}
 		else {
-			shadowDomains.set(plot, domain);
+			shadowDomains.set(this, domain);
 		}
-		plot.invalidate();
+		this.invalidate();
 	},
 
-	plot<T>(): ColumnPointPlot<T> {
-		const plot: ColumnPlot<T, ColumnPlotState<T>> = this;
-		const series = columnSeries.get(plot);
-		const { columnHeight, columnSpacing, columnWidth: displayWidth, domain: [domainMin, domainMax] } = plot;
+	plot<T>(this: ColumnPlot<T, ColumnPlotState<T>>): ColumnPointPlot<T> {
+		const series = columnSeries.get(this);
+		const { columnHeight, columnSpacing, columnWidth: displayWidth, domain: [domainMin, domainMax] } = this;
 
 		let mostNegativeRelValue = 0;
 		let mostNegativeValue = 0;

--- a/src/render/mixins/createInputSeriesMixin.ts
+++ b/src/render/mixins/createInputSeriesMixin.ts
@@ -70,7 +70,7 @@ const observables = new WeakMap<InputSeries<any, InputSeriesState<any>>, Observa
 
 const createInputSeries: InputSeriesFactory<any> = createStateful
 	.extend({
-		get inputSeries() {
+		get inputSeries(this: InputSeries<any, InputSeriesState<any>>) {
 			return observables.get(this);
 		}
 	})

--- a/src/render/mixins/createInputSeriesMixin.ts
+++ b/src/render/mixins/createInputSeriesMixin.ts
@@ -80,7 +80,17 @@ const createInputSeries: InputSeriesFactory<any> = createStateful
 		initialize<T>(instance: InputSeries<T, InputSeriesState<T>>, { inputSeries }: InputSeriesOptions<T, InputSeriesState<T>> = {}) {
 			if (inputSeries) {
 				// Create an observable if the data option was provided.
-				let observable: Observable<T[]> = isArrayLike(inputSeries) || isIterable(inputSeries) ? Observable.from([from(inputSeries)]) : inputSeries;
+				let observable: Observable<T[]>;
+				if (isArrayLike(inputSeries)) {
+					observable = Observable.from([from(inputSeries)]);
+				}
+				else if (isIterable(inputSeries)) {
+					// The repetition is a workaround for <https://github.com/dojo/shim/issues/9>.
+					observable = Observable.from([from(inputSeries)]);
+				}
+				else {
+					observable = inputSeries;
+				}
 				observables.set(instance, observable);
 				instance.emit({
 					type: 'inputserieschange',

--- a/src/render/mixins/createSvgRootMixin.ts
+++ b/src/render/mixins/createSvgRootMixin.ts
@@ -61,20 +61,18 @@ const shadowWidths = new WeakMap<SvgRoot<SvgRootState>, number>();
 const createSvgRootMixin = createStateful
 	.mixin({
 		mixin: <SvgRootMixin> {
-			get height() {
-				const root: SvgRoot<SvgRootState> = this;
-				const { height = shadowHeights.get(root) } = root.state || {};
+			get height(this: SvgRoot<SvgRootState>) {
+				const { height = shadowHeights.get(this) } = this.state || {};
 				return height;
 			},
 
 			set height(height) {
-				const root: SvgRoot<SvgRootState> = this;
-				if (root.state) {
-					root.setState({ height });
+				if (this.state) {
+					this.setState({ height });
 				}
 				else {
-					shadowHeights.set(root, height);
-					root.invalidate();
+					shadowHeights.set(this, height);
+					this.invalidate();
 				}
 			},
 
@@ -84,27 +82,24 @@ const createSvgRootMixin = createStateful
 
 			set tagName(noop) {},
 
-			get width() {
-				const root: SvgRoot<SvgRootState> = this;
-				const { width = shadowWidths.get(root) } = root.state || {};
+			get width(this: SvgRoot<SvgRootState>) {
+				const { width = shadowWidths.get(this) } = this.state || {};
 				return width;
 			},
 
 			set width(width) {
-				const root: SvgRoot<SvgRootState> = this;
-				if (root.state) {
-					root.setState({ width });
+				if (this.state) {
+					this.setState({ width });
 				}
 				else {
-					shadowWidths.set(root, width);
-					root.invalidate();
+					shadowWidths.set(this, width);
+					this.invalidate();
 				}
 			},
 
-			getRootAttributes(): VNodeProperties {
-				const root: SvgRoot<SvgRootState> = this;
+			getRootAttributes(this: SvgRoot<SvgRootState>): VNodeProperties {
 				// TODO: Move defaults into height/weight getters on root.
-				const { height, width } = root;
+				const { height, width } = this;
 				return {
 					height: String(height),
 					width: String(width),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
 		"declaration": false,
 		"module": "umd",
 		"noImplicitAny": true,
+		"noImplicitThis": true,
 		"outDir": "_build/",
 		"baseUrl": "node_modules",
 		"paths": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,53 +1,37 @@
 {
-	"version": "1.8.10",
+	"version": "2.0.0",
 	"compilerOptions": {
 		"declaration": false,
 		"module": "umd",
 		"noImplicitAny": true,
 		"outDir": "_build/",
+		"baseUrl": "node_modules",
+		"paths": {
+			"dojo-compose/*": [
+				"dojo-compose/dist/umd/*"
+			],
+			"dojo-core/*": [
+				"dojo-core/dist/umd/*"
+			],
+			"dojo-has/*": [
+				"dojo-has/dist/umd/*"
+			],
+			"dojo-shim/*": [
+				"dojo-shim/dist/umd/*"
+			],
+			"dojo-widgets/*": [
+				"dojo-widgets/dist/umd/*"
+			]
+		},
 		"removeComments": false,
 		"sourceMap": true,
 		"target": "es5",
 		"moduleResolution": "classic"
 	},
-	"filesGlob": [
-		"./typings/index.d.ts",
+	"include": [
 		"./examples/**/*.ts",
 		"./src/**/*.ts",
-		"./tests/**/*.ts"
-	],
-	"files": [
-		"./typings/index.d.ts",
-		"./examples/app.ts",
-		"./examples/axes.ts",
-		"./examples/index.ts",
-		"./examples/negatives.ts",
-		"./examples/play-counts.ts",
-		"./examples/stdout.ts",
-		"./src/data/accumulate.ts",
-		"./src/data/columnar.ts",
-		"./src/data/interfaces.d.ts",
-		"./src/data/max.ts",
-		"./src/data/relative-values.ts",
-		"./src/data/sort.ts",
-		"./src/data/sum.ts",
-		"./src/main.ts",
-		"./src/render/createChart.ts",
-		"./src/render/createColumnChart.ts",
-		"./src/render/createGroupedColumnChart.ts",
-		"./src/render/createStackedColumnChart.ts",
-		"./src/render/interfaces.ts",
-		"./src/render/mixins/createAxesMixin.ts",
-		"./src/render/mixins/createColumnPlotMixin.ts",
-		"./src/render/mixins/createInputSeriesMixin.ts",
-		"./src/render/mixins/createSvgRootMixin.ts",
-		"./tests/functional/all.ts",
-		"./tests/intern-local.ts",
-		"./tests/intern-saucelabs.ts",
-		"./tests/intern.ts",
-		"./tests/support/Reporter.ts",
-		"./tests/support/util.ts",
-		"./tests/unit/all.ts",
-		"./tests/unit/main.ts"
+		"./tests/**/*.ts",
+		"./typings/index.d.ts"
 	]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,5 +33,10 @@
 		"./src/**/*.ts",
 		"./tests/**/*.ts",
 		"./typings/index.d.ts"
+	],
+	"exclude": [
+		"_build",
+		"dist",
+		"node_modules"
 	]
 }

--- a/typings.json
+++ b/typings.json
@@ -1,11 +1,6 @@
 {
 	"name": "dojo-dataviz",
 	"globalDependencies": {
-		"dojo-compose": "npm:dojo-compose",
-		"dojo-core": "npm:dojo-core",
-		"dojo-has": "npm:dojo-has",
-		"dojo-shim": "npm:dojo-shim",
-		"dojo-widgets": "npm:dojo-widgets",
 		"extra-immutable": "github:dojo/typings/custom/dojo2-extras/immutable.d.ts#004fc065b3b24412c9b6575cdc06545964c370b5",
 		"extra-maquette": "github:dojo/typings/custom/dojo2-extras/maquette.d.ts#004fc065b3b24412c9b6575cdc06545964c370b5",
 		"extra-rxjs": "github:dojo/typings/custom/dojo2-extras/rxjs.d.ts#004fc065b3b24412c9b6575cdc06545964c370b5"


### PR DESCRIPTION
Assumes `dojo-widgets@next` has been published with TS2 support (which is not currently the case).

Does not yet enable `strictNullChecks`.
