### PR TITLE
WIP UI Events

### DIFF
--- a/examples/events.ts
+++ b/examples/events.ts
@@ -1,0 +1,109 @@
+import createMemoryStore from 'dojo-widgets/util/createMemoryStore';
+import projector from 'dojo-widgets/projector';
+
+import max from 'src/data/max';
+import sum from 'src/data/sum';
+import sort from 'src/data/sort';
+import createColumnChart from 'src/render/createColumnChart';
+import createGroupedColumnChart, { SelectColumnInGroupEvent } from 'src/render/createGroupedColumnChart';
+
+import getPlayCounts, { PlayCount } from './play-counts';
+
+const playCounts = getPlayCounts().share();
+const byProvince = sort(playCounts, ({ province }) => province);
+
+const stateFrom = createMemoryStore({
+	data: [
+		{ id: 'percentageChart' },
+		{ id: 'groupedByProvinceChart' }
+	]
+});
+
+const percentageChart = createColumnChart<PlayCount>({
+	bottomAxis: {
+		inputs: {
+			labelSelector({ input }) { return input.artist; }
+		},
+		labels: { anchor: 'middle', textAnchor: 'end', rotation: -45, offset: -5 },
+		ticks: { anchor: 'end', length: 10, zeroth: true }
+	},
+	columnHeight: 100,
+	columnSpacing: 1,
+	columnWidth: 20,
+	divisorOperator: sum,
+	height: 250,
+	id: 'percentageChart',
+	inputSeries: playCounts,
+	leftAxis: {
+		labels: { anchor: 'end' },
+		range: { end: 100, fixed: true, stepSize: 20 },
+		ticks: { length: 10 }
+	},
+	stateFrom,
+	valueSelector(input) { return input.count; },
+	width: 300,
+	xInset: 50,
+	yInset: 15
+});
+
+const groupedByProvinceChart = createGroupedColumnChart<string, PlayCount>({
+	bottomAxis: {
+		inputs: {
+			labelSelector({ input }) { return input; }
+		},
+		labels: { anchor: 'middle', textAnchor: 'end', rotation: -45, offset: -5 },
+		ticks: { anchor: 'end', length: 10, zeroth: true }
+	},
+	columnHeight: 100,
+	columnSpacing: 1,
+	columnWidth: 10,
+	divisorOperator: max,
+	height: 230,
+	groupSelector(input) { return input.province; },
+	groupSpacing: 10,
+	id: 'groupedByProvinceChart',
+	inputSeries: byProvince,
+	leftAxis: {
+		labels: { anchor: 'end' },
+		range: { stepSize: 5000 },
+		ticks: { length: 10 }
+	},
+	state: {
+		styles: { marginTop: '20px' }
+	},
+	topAxis: {
+		inputs: {
+			labelSelector({ totalValue }) { return String(totalValue); }
+		},
+		labels: { anchor: 'middle', textAnchor: 'end', rotation: 45, offset: -5 },
+		ticks: { anchor: 'end', length: 10, zeroth: true }
+	},
+	stateFrom,
+	valueSelector(input) { return input.count; },
+	width: 300,
+	xInset: 75,
+	yInset: 25
+});
+
+// Make the charts available to the console.
+(<any> window).percentageChart = percentageChart;
+(<any> window).groupedByProvinceChart = groupedByProvinceChart;
+
+percentageChart.on('selectcolumn', ({ input: { artist, count } }) => {
+	console.log('%s: %i plays', artist, count);
+});
+
+// FIXME: Why can't GroupedColumnChart override the event type for 'selectcolumn'?
+groupedByProvinceChart.on(
+	'selectcolumn',
+	({
+		group,
+		groupPoint: { datum: { totalValue } },
+		input: { artist, count }
+	}: SelectColumnInGroupEvent<string, PlayCount>) => {
+		console.log('%s: %i plays, %i% of total in %s', artist, count, count / totalValue * 100, group);
+	}
+);
+
+projector.append([percentageChart, groupedByProvinceChart]);
+projector.attach();

--- a/src/render/createColumnChart.ts
+++ b/src/render/createColumnChart.ts
@@ -88,10 +88,11 @@ const createColumnChart: ColumnChartFactory<any> = createChart
 				}, axes.top));
 			}
 
+			const groups = this.renderPlotPoints(plot.points, plot.height, axes.extraHeight);
 			nodes.push(h('g', {
 				key: 'plot',
 				'transform': `translate(${xInset} ${yInset + axes.extraHeight})`
-			}, this.renderPlotPoints(plot.points)));
+			}, groups.map((nodes, key) => h('g', { key }, nodes))));
 
 			return nodes;
 		}

--- a/src/render/createStackedColumnChart.ts
+++ b/src/render/createStackedColumnChart.ts
@@ -3,7 +3,7 @@ import { assign } from 'dojo-core/lang';
 import { from } from 'dojo-shim/array';
 import Map from 'dojo-shim/Map';
 import WeakMap from 'dojo-shim/WeakMap';
-import { h, VNode, VNodeProperties } from 'maquette/maquette';
+import { h, VNode } from 'maquette/maquette';
 
 import { Datum } from '../data/interfaces';
 import createColumnChart, {
@@ -350,14 +350,20 @@ const createStackedColumnChart: StackedColumnChartFactory<any, any> = createColu
 			},
 
 			around: {
-				renderPlotPoints<G, T>(renderColumns: (points: ColumnPoint<T>[]) => VNode[]) {
-					return function(this: any, stackPoints: StackedColumnPoint<G, T>[]) {
-						return stackPoints.map(({ columnPoints, datum }) => {
-							const props: VNodeProperties = {
-								key: datum.input
-							};
-							return h('g', props, renderColumns.call(this, columnPoints));
-						});
+				renderPlotPoints<G, T>(renderColumns: (points: ColumnPoint<T>[], plotHeight: number, extraHeight: number) => VNode[][]) {
+					return function(this: any, stackPoints: StackedColumnPoint<G, T>[], plotHeight: number, extraHeight: number) {
+						const outerNodes: VNode[] = [];
+						const innerNodes: VNode[] = [];
+						const stackNodes: VNode[] = [];
+
+						for (const { columnPoints, datum: { input: key } } of stackPoints) {
+							const [outer, inner, nodes] = renderColumns.call(this, columnPoints, plotHeight, extraHeight);
+							outerNodes.push(outer[0]);
+							innerNodes.push(inner[0]);
+							stackNodes.push(h('g', { key }, nodes));
+						}
+
+						return [outerNodes, innerNodes, stackNodes];
 					};
 				}
 			}

--- a/src/render/mixins/createColumnPlotMixin.ts
+++ b/src/render/mixins/createColumnPlotMixin.ts
@@ -149,7 +149,7 @@ export interface ColumnPlotMixin<T> {
 	/**
 	 * Create VNodes for each column given its points.
 	 */
-	renderPlotPoints(points: ColumnPoint<T>[]): VNode[];
+	renderPlotPoints(points: ColumnPoint<T>[], plotHeight: number, extraHeight: number): VNode[][];
 }
 
 /**
@@ -353,16 +353,45 @@ const createColumnPlot: ColumnPlotFactory<any> = compose({
 		};
 	},
 
-	renderPlotPoints<T>(points: ColumnPoint<T>[]) {
-		return points.map(({ datum, displayHeight, displayWidth, offsetLeft, x1, y1 }) => {
-			return h('rect', {
-				key: datum.input,
+	renderPlotPoints<T>(points: ColumnPoint<T>[], plotHeight: number, extraHeight: number) {
+		const outerNodes: VNode[] = [];
+		const innerNodes: VNode[] = [];
+		const columnNodes: VNode[] = [];
+
+		const fullHeight = String(plotHeight + extraHeight);
+		const fullY = String(-extraHeight);
+		for (const { datum: { input: key }, displayHeight, displayWidth, offsetLeft, x1, x2, y1 } of points) {
+			const innerWidth = String(displayWidth);
+			const innerX = String(x1 + offsetLeft);
+
+			outerNodes.push(h('rect', {
+				key,
+				'fill-opacity': '0',
+				height: fullHeight,
+				width: String(x2 - x1),
+				x: String(x1),
+				y: fullY
+			}));
+
+			innerNodes.push(h('rect', {
+				key,
+				'fill-opacity': '0',
+				height: fullHeight,
+				width: innerWidth,
+				x: innerX,
+				y: fullY
+			}));
+
+			columnNodes.push(h('rect', {
+				key,
 				height: String(displayHeight),
-				width: String(displayWidth),
-				x: String(x1 + offsetLeft),
+				width: innerWidth,
+				x: innerX,
 				y: String(y1)
-			});
-		});
+			}));
+		}
+
+		return [outerNodes, innerNodes, columnNodes];
 	}
 }).mixin({
 	mixin: createInputSeries,


### PR DESCRIPTION
A possible approach to emitting semantic events on user interaction.

Rather than computing which part of the chart pointer events are coming from this renders additional nodes to trap DOM events. This works well for column charts but I'm not sure how it'll work out for other chart types.

The additional elements could also be useful for highlighting columns. To this end I'm rendering "outer" elements, which include any spacing around columns and groups, and "inner" elements, which cover the column / group excluding spacing, for the full height of the chart.

The goal is to emit semantic events. E.g. for the column charts that would be when a specific column is selected. In grouped or stacked charts this event may bubble and emit for the group / stack. It may bubble further and emit for the inner and outer columns / groups.

We'd also need to be able to track enter/exit events, and again these might bubble.

Event objects may need to include details on what levels of the chart hierarchy are "active" under the event so that UI code can respond appropriately.

We need to provide ways for the UI to affect classes on the columns and other elements, either via the event object (expose the `VNode`s?) or via the chart object itself.

Charts are rerendered when their data changes. Synthetic events may need to be emitted since the data can change without pointer input. If columns are added or removed, a previously "hovered" column may no longer sit underneath the pointer. Similarly a column's height may change.
