### PR TITLE
Various improvements

### DIFF
--- a/examples/app.ts
+++ b/examples/app.ts
@@ -4,7 +4,7 @@ import projector from 'dojo-widgets/projector';
 import max from '../src/data/max';
 import sum from '../src/data/sum';
 import sort from '../src/data/sort';
-import createColumnChart from '../src/render/createColumnChart';
+import createColumnChart, { ColumnChartFactory } from '../src/render/createColumnChart';
 import createGroupedColumnChart from '../src/render/createGroupedColumnChart';
 import createStackedColumnChart from '../src/render/createStackedColumnChart';
 
@@ -21,9 +21,6 @@ const store = createMemoryStore({
 			columnHeight: 100,
 			xInset: 50,
 			yInset: 15
-		},
-		{
-			id: 'groupedByProvinceChart'
 		}
 	]
 });
@@ -52,22 +49,29 @@ const percentageChart = createColumnChart<PlayCount>({
 		labels: { anchor: 'end' },
 		ticks: { length: 10, zeroth: true }
 	},
-	columnSpacing: 1,
 	divisorOperator: sum,
 	state: {
-		// Example of passing height via the state
-		height: 250
+		height: 250,
+		columnSpacing: 1,
+		columnWidth: 20,
+		width: 300
 	},
 	stateFrom: store,
-	valueSelector(input) { return input.count; },
-	// Example of passing width
-	width: 300
+	valueSelector(input) { return input.count; }
 });
 
-// Example of setting columnWidth
-percentageChart.columnWidth = 20;
+const createAbsoluteChart: ColumnChartFactory<PlayCount> = createColumnChart.extend({
+	columnHeight: 100,
+	columnSpacing: 3,
+	columnWidth: 20,
+	domain: 35000,
+	height: 260,
+	width: 300,
+	xInset: 50,
+	yInset: 30
+});
 
-const absoluteChart = createColumnChart<PlayCount>({
+const absoluteChart = createAbsoluteChart({
 	bottomAxis: {
 		inputs: {
 			labelSelector({ input }) { return input.artist; }
@@ -80,18 +84,10 @@ const absoluteChart = createColumnChart<PlayCount>({
 		range: { stepSize: 5000 },
 		ticks: { length: 10 }
 	},
-	columnHeight: 100,
-	columnSpacing: 3,
-	columnWidth: 20,
-	domain: 35000,
 	// Example of passing an observable to the chart.
 	inputSeries: playCounts,
 	divisorOperator: max,
-	height: 260,
-	valueSelector(input) { return input.count; },
-	width: 300,
-	xInset: 50,
-	yInset: 30
+	valueSelector(input) { return input.count; }
 });
 
 const groupedByProvinceChart = createGroupedColumnChart<string, PlayCount>({
@@ -116,24 +112,23 @@ const groupedByProvinceChart = createGroupedColumnChart<string, PlayCount>({
 		labels: { anchor: 'middle', textAnchor: 'end', rotation: 45, offset: -5 },
 		ticks: { anchor: 'end', length: 10, zeroth: true }
 	},
-	columnHeight: 100,
-	columnSpacing: 1,
-	columnWidth: 10,
 	state: {
-		styles: { marginTop: '20px' }
+		columnHeight: 100,
+		columnSpacing: 1,
+		columnWidth: 10,
+		groupSpacing: 10,
+		height: 230,
+		styles: { marginTop: '20px' },
+		width: 300,
+		xInset: 75,
+		yInset: 25
 	},
 	// Example of passing an observable to the chart.
 	inputSeries: byProvince,
 	divisorOperator: max,
 	groupSelector(input) { return input.province; },
-	groupSpacing: 10,
-	height: 230,
-	valueSelector(input) { return input.count; },
-	width: 300
+	valueSelector(input) { return input.count; }
 });
-
-groupedByProvinceChart.xInset = 75;
-groupedByProvinceChart.yInset = 25;
 
 const stackedByProvinceChart = createStackedColumnChart<string, PlayCount>({
 	bottomAxis: {
@@ -157,25 +152,24 @@ const stackedByProvinceChart = createStackedColumnChart<string, PlayCount>({
 		labels: { anchor: 'middle', textAnchor: 'end', rotation: 45, offset: -5 },
 		ticks: { anchor: 'end', length: 10, zeroth: true }
 	},
-	columnHeight: 200,
-	columnSpacing: 10,
-	columnWidth: 20,
-	domain: 50000,
 	state: {
-		styles: { marginTop: '20px' }
+		columnHeight: 200,
+		columnSpacing: 10,
+		columnWidth: 20,
+		domain: 50000,
+		height: 330,
+		stackSpacing: 1,
+		styles: { marginTop: '20px' },
+		width: 300,
+		xInset: 75,
+		yInset: 25
 	},
 	// Example of passing an observable to the chart.
 	inputSeries: byProvince,
 	divisorOperator: max,
 	stackSelector(input) { return input.province; },
-	stackSpacing: 1,
-	height: 330,
-	valueSelector(input) { return input.count; },
-	width: 300
+	valueSelector(input) { return input.count; }
 });
-
-stackedByProvinceChart.xInset = 75;
-stackedByProvinceChart.yInset = 25;
 
 // Make the charts available to the console.
 (<any> window).absoluteChart = absoluteChart;

--- a/examples/app.ts
+++ b/examples/app.ts
@@ -1,3 +1,4 @@
+import global from 'dojo-core/global';
 import createMemoryStore from 'dojo-stores/createMemoryStore';
 import projector from 'dojo-widgets/projector';
 
@@ -172,10 +173,10 @@ const stackedByProvinceChart = createStackedColumnChart<string, PlayCount>({
 });
 
 // Make the charts available to the console.
-(<any> window).absoluteChart = absoluteChart;
-(<any> window).groupedByProvinceChart = groupedByProvinceChart;
-(<any> window).percentageChart = percentageChart;
-(<any> window).stackedByProvinceChart = stackedByProvinceChart;
+global.absoluteChart = absoluteChart;
+global.groupedByProvinceChart = groupedByProvinceChart;
+global.percentageChart = percentageChart;
+global.stackedByProvinceChart = stackedByProvinceChart;
 
 projector.append([percentageChart, absoluteChart, groupedByProvinceChart, stackedByProvinceChart]);
 projector.attach();

--- a/examples/axes.ts
+++ b/examples/axes.ts
@@ -1,6 +1,7 @@
 // Hey! So this file renders a variety of axis options. It's by no means exhaustive, or pretty, or even sensible given
 // for a column chart. It's just a way to visually verify some of the render logic, if you know what you're looking for.
 
+import global from 'dojo-core/global';
 import { assign, deepAssign } from 'dojo-core/lang';
 import projector from 'dojo-widgets/projector';
 
@@ -61,7 +62,7 @@ const inputs = createColumnChart<number>(createAxesConfiguration({
 	}
 }, chartOptions));
 
-(<any> window).inputs = inputs;
+global.inputs = inputs;
 
 const inputsGridLines = createColumnChart<number>(createAxesConfiguration({
 	inputs: {

--- a/examples/axes.ts
+++ b/examples/axes.ts
@@ -14,17 +14,19 @@ const inputSeries = [5, 15, 25, MAX_INPUT];
 
 const chartOptions: ColumnChartOptions<number, Datum<number>, any> = {
 	inputSeries,
-	width: 150,
-	height: 150,
-	columnHeight: 100,
-	columnWidth: 20,
-	columnSpacing: 1,
 	divisorOperator: max,
+	state: {
+		width: 150,
+		height: 150,
+		columnHeight: 100,
+		columnWidth: 20,
+		columnSpacing: 1,
+		xInset: 25,
+		yInset: 25
+	},
 	valueSelector(input) {
 		return input;
-	},
-	xInset: 25,
-	yInset: 25
+	}
 };
 
 function createAxesConfiguration(shared: AxisConfiguration<Datum<number>>, chartOptions: any): any {
@@ -58,6 +60,8 @@ const inputs = createColumnChart<number>(createAxesConfiguration({
 		zeroth: true
 	}
 }, chartOptions));
+
+(<any> window).inputs = inputs;
 
 const inputsGridLines = createColumnChart<number>(createAxesConfiguration({
 	inputs: {

--- a/examples/negatives.ts
+++ b/examples/negatives.ts
@@ -10,20 +10,22 @@ const basic = createColumnChart<number>({
 		inputs: true,
 		ticks: { anchor: 'end', length: 5, zeroth: true }
 	},
-	columnHeight: 150,
-	columnSpacing: 3,
-	columnWidth: 10,
 	divisorOperator: max,
-	height: 200,
 	inputSeries: [-5, 5, 10],
 	leftAxis: {
 		labels: { anchor: 'end' },
 		range: { stepSize: 5 },
 		ticks: { length: 5, zeroth: true }
 	},
-	valueSelector(input) { return input; },
-	width: 100,
-	xInset: 30
+	state: {
+		columnHeight: 150,
+		columnSpacing: 3,
+		columnWidth: 10,
+		height: 200,
+		width: 100,
+		xInset: 30
+	},
+	valueSelector(input) { return input; }
 });
 
 const domain = createColumnChart<number>({
@@ -31,21 +33,23 @@ const domain = createColumnChart<number>({
 		inputs: true,
 		ticks: { anchor: 'end', length: 5, zeroth: true }
 	},
-	columnHeight: 200,
-	columnSpacing: 3,
-	columnWidth: 10,
 	divisorOperator: max,
-	domain: [-10, 10],
-	height: 200,
 	inputSeries: [-5, 5, 10],
 	leftAxis: {
 		range: { stepSize: 5 },
 		labels: { anchor: 'end' },
 		ticks: { anchor: 'end', length: 5, zeroth: true }
 	},
-	valueSelector(input) { return input; },
-	width: 100,
-	xInset: 30
+	state: {
+		columnHeight: 200,
+		columnSpacing: 3,
+		columnWidth: 10,
+		domain: [-10, 10],
+		height: 200,
+		width: 100,
+		xInset: 30
+	},
+	valueSelector(input) { return input; }
 });
 
 const allNegative = createColumnChart<number>({
@@ -53,11 +57,7 @@ const allNegative = createColumnChart<number>({
 		inputs: true,
 		ticks: { anchor: 'end', length: 5, zeroth: true }
 	},
-	columnHeight: 150,
-	columnSpacing: 3,
-	columnWidth: 10,
 	divisorOperator: max,
-	height: 200,
 	inputSeries: [-5, -10],
 	leftAxis: {
 		inputs: {
@@ -66,9 +66,15 @@ const allNegative = createColumnChart<number>({
 		labels: { anchor: 'end' },
 		ticks: { anchor: 'end', length: 5, zeroth: true }
 	},
-	valueSelector(input) { return input; },
-	width: 100,
-	xInset: 30
+	state: {
+		columnHeight: 150,
+		columnSpacing: 3,
+		columnWidth: 10,
+		height: 200,
+		width: 100,
+		xInset: 30
+	},
+	valueSelector(input) { return input; }
 });
 
 const allNegativeDomain = createColumnChart<number>({
@@ -76,21 +82,23 @@ const allNegativeDomain = createColumnChart<number>({
 		inputs: true,
 		ticks: { anchor: 'end', length: 5, zeroth: true }
 	},
-	columnHeight: 200,
-	columnSpacing: 3,
-	columnWidth: 10,
 	divisorOperator: max,
-	domain: -15,
-	height: 200,
 	inputSeries: [-5, -10],
 	leftAxis: {
 		range: { stepSize: 5 },
 		labels: { anchor: 'end' },
 		ticks: { anchor: 'end', length: 5, zeroth: true }
 	},
-	valueSelector(input) { return input; },
-	width: 100,
-	xInset: 30
+	state: {
+		columnHeight: 200,
+		columnSpacing: 3,
+		columnWidth: 10,
+		domain: -15,
+		height: 200,
+		width: 100,
+		xInset: 30
+	},
+	valueSelector(input) { return input; }
 });
 
 const group = createGroupedColumnChart<string, [string, number]>({
@@ -101,11 +109,7 @@ const group = createGroupedColumnChart<string, [string, number]>({
 		labels: { anchor: 'middle', textAnchor: 'end', rotation: -45, offset: -5 },
 		ticks: { anchor: 'end', length: 5, zeroth: true }
 	},
-	columnHeight: 150,
-	columnSpacing: 3,
-	columnWidth: 10,
 	divisorOperator: max,
-	height: 200,
 	groupSelector(input) { return input[0]; },
 	inputSeries: [['foo', -5], ['foo', -5], ['bar', 5], ['bar', 10]],
 	leftAxis: {
@@ -113,9 +117,15 @@ const group = createGroupedColumnChart<string, [string, number]>({
 		range: { stepSize: 5 },
 		ticks: { length: 5, zeroth: true }
 	},
-	valueSelector(input) { return input[1]; },
-	width: 100,
-	xInset: 30
+	state: {
+		columnHeight: 150,
+		columnSpacing: 3,
+		columnWidth: 10,
+		height: 200,
+		width: 100,
+		xInset: 30
+	},
+	valueSelector(input) { return input[1]; }
 });
 
 const stack = createStackedColumnChart<string, [string, number]>({
@@ -126,11 +136,7 @@ const stack = createStackedColumnChart<string, [string, number]>({
 		labels: { anchor: 'middle', textAnchor: 'end', rotation: -45, offset: -5 },
 		ticks: { anchor: 'end', length: 5, zeroth: true }
 	},
-	columnHeight: 150,
-	columnSpacing: 3,
-	columnWidth: 10,
 	divisorOperator: max,
-	height: 200,
 	inputSeries: [['foo', -5], ['foo', -5], ['bar', 5], ['bar', 10], ['baz', -5], ['baz', 5]],
 	leftAxis: {
 		labels: { anchor: 'end' },
@@ -138,10 +144,16 @@ const stack = createStackedColumnChart<string, [string, number]>({
 		ticks: { length: 5, zeroth: true }
 	},
 	stackSelector(input) { return input[0]; },
-	stackSpacing: 1,
-	valueSelector(input) { return input[1]; },
-	width: 100,
-	xInset: 30
+	state: {
+		columnHeight: 150,
+		columnSpacing: 3,
+		columnWidth: 10,
+		height: 200,
+		stackSpacing: 1,
+		width: 100,
+		xInset: 30
+	},
+	valueSelector(input) { return input[1]; }
 });
 
 const stackDomain = createStackedColumnChart<string, [string, number]>({
@@ -152,12 +164,7 @@ const stackDomain = createStackedColumnChart<string, [string, number]>({
 		labels: { anchor: 'middle', textAnchor: 'end', rotation: -45, offset: -5 },
 		ticks: { anchor: 'end', length: 5, zeroth: true }
 	},
-	columnHeight: 150,
-	columnSpacing: 3,
-	columnWidth: 10,
 	divisorOperator: max,
-	domain: [-15, 15],
-	height: 200,
 	inputSeries: [['foo', -5], ['foo', -5], ['bar', 5], ['bar', 10], ['baz', -5], ['baz', 5]],
 	leftAxis: {
 		labels: { anchor: 'end' },
@@ -165,10 +172,17 @@ const stackDomain = createStackedColumnChart<string, [string, number]>({
 		ticks: { length: 5, zeroth: true }
 	},
 	stackSelector(input) { return input[0]; },
-	stackSpacing: 1,
-	valueSelector(input) { return input[1]; },
-	width: 100,
-	xInset: 30
+	state: {
+		columnHeight: 150,
+		columnSpacing: 3,
+		columnWidth: 10,
+		domain: [-15, 15],
+		height: 200,
+		stackSpacing: 1,
+		width: 100,
+		xInset: 30
+	},
+	valueSelector(input) { return input[1]; }
 });
 
 (<any> window).basic = basic;

--- a/examples/negatives.ts
+++ b/examples/negatives.ts
@@ -1,3 +1,4 @@
+import global from 'dojo-core/global';
 import projector from 'dojo-widgets/projector';
 
 import max from '../src/data/max';
@@ -185,13 +186,13 @@ const stackDomain = createStackedColumnChart<string, [string, number]>({
 	valueSelector(input) { return input[1]; }
 });
 
-(<any> window).basic = basic;
-(<any> window).domain = domain;
-(<any> window).allNegative = allNegative;
-(<any> window).allNegativeDomain = allNegativeDomain;
-(<any> window).group = group;
-(<any> window).stack = stack;
-(<any> window).stackDomain = stackDomain;
+global.basic = basic;
+global.domain = domain;
+global.allNegative = allNegative;
+global.allNegativeDomain = allNegativeDomain;
+global.group = group;
+global.stack = stack;
+global.stackDomain = stackDomain;
 
 projector.append([
 	basic, domain,

--- a/examples/play-counts.ts
+++ b/examples/play-counts.ts
@@ -9,7 +9,7 @@ export interface PlayCount {
 	province: 'British Columbia' | 'Manitoba' | 'Nova Scotia' | 'Ontario' | 'Quebec';
 }
 
-export default function getObservable (): Observable<PlayCount[]> {
+export default function getObservable(): Observable<PlayCount[]> {
 	const source = new Observable<PlayCount>((subscriber: Subscriber<PlayCount>) => {
 		const data: PlayCount[] = [
 			{ artist: 'Hawksley Workman', count: 31910, province: 'Ontario' },

--- a/src/data/accumulate.ts
+++ b/src/data/accumulate.ts
@@ -1,5 +1,5 @@
 import { Observable } from 'rxjs/Rx';
 
-export default function accumulate<T> (observable: Observable<T>): Observable<T[]> {
+export default function accumulate<T>(observable: Observable<T>): Observable<T[]> {
 	return observable.scan<T[]>((acc, input) => acc.concat(input), []);
 }

--- a/src/data/columnar.ts
+++ b/src/data/columnar.ts
@@ -9,7 +9,7 @@ import {
 import relativeValues from './relative-values';
 
 export interface Column<T> extends Datum<T> {
-	relativeValue: number;
+	readonly relativeValue: number;
 }
 
 export default function columnar<T>(

--- a/src/data/columnar.ts
+++ b/src/data/columnar.ts
@@ -12,7 +12,7 @@ export interface Column<T> extends Datum<T> {
 	relativeValue: number;
 }
 
-export default function columnar<T> (
+export default function columnar<T>(
 	observable: InputObservable<T>,
 	valueSelector: ValueSelector<T>,
 	divisorOperator: DivisorOperator<T>
@@ -21,7 +21,7 @@ export default function columnar<T> (
 	const divisors = divisorOperator(shared, valueSelector);
 	return relativeValues(shared, valueSelector, divisors)
 		.map((inputsAndRelativeValues) => {
-			return inputsAndRelativeValues.map(([input, relativeValue]) => {
+			return inputsAndRelativeValues.map(([ input, relativeValue ]) => {
 				const value = valueSelector(input);
 				// Ensure the relative value retains the same sign as the input's value, irrespective of the divisors.
 				if (value < 0 && relativeValue > 0 || value > 0 && relativeValue < 0) {

--- a/src/data/interfaces.d.ts
+++ b/src/data/interfaces.d.ts
@@ -2,8 +2,8 @@ import { Iterable } from 'dojo-shim/iterator';
 import { Observable } from 'rxjs/Rx';
 
 export interface Datum<T> {
-	input: T;
-	value: number;
+	readonly input: T;
+	readonly value: number;
 }
 
 export type Divisor = Observable<number>;

--- a/src/data/max.ts
+++ b/src/data/max.ts
@@ -2,7 +2,7 @@ import { forOf } from 'dojo-shim/iterator';
 
 import { DivisorOperator, InputObservable, ValueSelector } from './interfaces';
 
-function max<T> (observable: InputObservable<T>, valueSelector: ValueSelector<T>) {
+function max<T>(observable: InputObservable<T>, valueSelector: ValueSelector<T>) {
 	return observable.map((inputs) => {
 		let max = 0;
 		forOf(inputs, (input) => {

--- a/src/data/relative-values.ts
+++ b/src/data/relative-values.ts
@@ -3,18 +3,18 @@ import { Observable } from 'rxjs/Rx';
 
 import { Divisor, InputObservable, ValueSelector } from './interfaces';
 
-export default function relativeValues<T> (
+export default function relativeValues<T>(
 	observable: InputObservable<T>,
 	valueSelector: ValueSelector<T>,
 	divisors: Divisor
-): Observable<[T, number][]> {
+): Observable<[ T, number ][]> {
 	return observable
 		.withLatestFrom(divisors)
-		.map(([inputs, divisor]) => {
-			const result: [T, number][] = [];
+		.map(([ inputs, divisor ]) => {
+			const result: [ T, number ][] = [];
 			forOf(inputs, (input) => {
 				// FIXME: Handle Infinity and -Infinity? (issue #5)
-				result.push([input, (valueSelector(input) || 0) / divisor]);
+				result.push([ input, (valueSelector(input) || 0) / divisor ]);
 			});
 			return result;
 		});

--- a/src/data/sort.ts
+++ b/src/data/sort.ts
@@ -4,17 +4,17 @@ import { Observable } from 'rxjs/Rx';
 
 import { InputObservable } from './interfaces';
 
-function defaultCompare (a: any, b: any): number {
+function defaultCompare(a: any, b: any): number {
 	const strA = String(a);
 	const strB = String(b);
 	return strA < strB && -1 || strA > strB && 1 || 0;
 }
 
-function identity<T> (value: T): T {
+function identity<T>(value: T): T {
 	return value;
 }
 
-export default function sort<T> (
+export default function sort<T>(
 	observable: InputObservable<T>,
 	comparableSelector: (input: T) => any = identity,
 	compareFunction: (a: any, b: any) => number = defaultCompare

--- a/src/data/sort.ts
+++ b/src/data/sort.ts
@@ -14,7 +14,7 @@ function identity<T>(value: T): T {
 	return value;
 }
 
-export default function sort<T>(
+export default function sort<T extends Object>(
 	observable: InputObservable<T>,
 	comparableSelector: (input: T) => any = identity,
 	compareFunction: (a: any, b: any) => number = defaultCompare

--- a/src/data/sum.ts
+++ b/src/data/sum.ts
@@ -2,7 +2,7 @@ import { forOf } from 'dojo-shim/iterator';
 
 import { DivisorOperator, InputObservable, ValueSelector } from './interfaces';
 
-function sum<T> (observable: InputObservable<T>, valueSelector: ValueSelector<T>) {
+function sum<T>(observable: InputObservable<T>, valueSelector: ValueSelector<T>) {
 	return observable.map((inputs) => {
 		let sum = 0;
 		forOf(inputs, (input) => {

--- a/src/render/createChart.ts
+++ b/src/render/createChart.ts
@@ -66,7 +66,7 @@ const createChart: ChartFactory = createWidget
 		aspectAdvice: {
 			before: {
 				getNodeAttributes(this: Chart<ChartState>, overrides?: VNodeProperties): VNodeProperties[] {
-					return [assign(this.getRootAttributes(), overrides)];
+					return [ assign(this.getRootAttributes(), overrides) ];
 				}
 			}
 		},

--- a/src/render/createChart.ts
+++ b/src/render/createChart.ts
@@ -1,8 +1,7 @@
 import { ComposeFactory } from 'dojo-compose/compose';
-import { assign } from 'dojo-core/lang';
 import createWidget, { Widget, WidgetOptions, WidgetState } from 'dojo-widgets/createWidget';
 import WeakMap from 'dojo-shim/WeakMap';
-import { VNode, VNodeProperties } from 'maquette';
+import { VNode } from 'maquette';
 
 import createSvgRootMixin, { SvgRoot, SvgRootOptions, SvgRootState } from './mixins/createSvgRootMixin';
 
@@ -63,14 +62,6 @@ const shadowYInsets = new WeakMap<Chart<ChartState>, number>();
 const createChart: ChartFactory = createWidget
 	.mixin(createSvgRootMixin)
 	.mixin({
-		aspectAdvice: {
-			before: {
-				getNodeAttributes(this: Chart<ChartState>, overrides?: VNodeProperties): VNodeProperties[] {
-					return [ assign(this.getRootAttributes(), overrides) ];
-				}
-			}
-		},
-
 		mixin: <ChartMixin> {
 			get xInset(this: Chart<ChartState>) {
 				const { xInset = shadowXInsets.get(this) } = this.state || {};

--- a/src/render/createChart.ts
+++ b/src/render/createChart.ts
@@ -1,6 +1,5 @@
 import { ComposeFactory } from 'dojo-compose/compose';
 import createWidget, { Widget, WidgetOptions, WidgetState } from 'dojo-widgets/createWidget';
-import WeakMap from 'dojo-shim/WeakMap';
 import { VNode } from 'maquette';
 
 import createSvgRootMixin, { SvgRoot, SvgRootOptions, SvgRootState } from './mixins/createSvgRootMixin';
@@ -17,91 +16,56 @@ export interface ChartState extends WidgetState, SvgRootState {
 	yInset?: number;
 }
 
-export type ChartOptions<S extends ChartState> = WidgetOptions<S> & SvgRootOptions<S> & {
-	/**
-	 * How many pixels from the left, within the <svg> root, the chart sthould be rendered.
-	 */
-	xInset?: number;
-
-	/**
-	 * How many pixels from the top, within the <svg> root, the chart sthould be rendered.
-	 */
-	yInset?: number;
-}
+export type ChartOptions<S extends ChartState> = WidgetOptions<S> & SvgRootOptions<S>;
 
 export interface ChartMixin {
 	/**
-	 * How many pixels from the left, within the <svg> root, the chart sthould be rendered.
+	 * Default return value for `getXInset()`, in case `xInset` is not present in the state.
 	 *
-	 * Defaults to 0.
+	 * If not provided, the default value that ends up being used is 0.
 	 */
-	xInset: number;
+	readonly xInset?: number;
+
+	/**
+	 * Default return value for `getYInset()`, in case `yInset` is not present in the state.
+	 *
+	 * If not provided, the default value that ends up being used is 0.
+	 */
+	readonly yInset?: number;
+
+	/**
+	 * How many pixels from the left, within the <svg> root, the chart sthould be rendered.
+	 */
+	getXInset(): number;
 
 	/**
 	 * How many pixels from the top, within the <svg> root, the chart sthould be rendered.
-	 *
-	 * Defaults to 0.
 	 */
-	yInset: number;
+	getYInset(): number;
 
 	getChildrenNodes(): VNode[];
 }
 
 export type Chart<S extends ChartState> = Widget<S> & SvgRoot<S> & ChartMixin;
 
-export interface ChartFactory extends ComposeFactory<
-	Chart<ChartState>,
-	ChartOptions<ChartState>
-> {
-	<S extends ChartState>(options?: ChartOptions<S>): Chart<S>;
-}
-
-interface PrivateState {
-	xInset: number;
-	yInset: number;
-}
-
-const privateStateMap = new WeakMap<Chart<ChartState>, PrivateState>();
+export type ChartFactory = ComposeFactory<Chart<ChartState>, ChartOptions<ChartState>>;
 
 const createChart: ChartFactory = createWidget
 	.mixin(createSvgRootMixin)
 	.extend({
-		get xInset(this: Chart<ChartState>) {
-			const { xInset = privateStateMap.get(this).xInset } = this.state || {};
+		getXInset(this: Chart<ChartState>) {
+			const { xInset = this.xInset || 0 } = this.state;
 			return xInset;
 		},
 
-		set xInset(xInset) {
-			if (this.state) {
-				this.setState({ xInset });
-			}
-			else {
-				privateStateMap.get(this).xInset = xInset;
-			}
-		},
-
-		get yInset(this: Chart<ChartState>) {
-			const { yInset = privateStateMap.get(this).yInset } = this.state || {};
-			return yInset;
-		},
-
-		set yInset(yInset) {
-			if (this.state) {
-				this.setState({ yInset });
-			}
-			else {
-				privateStateMap.get(this).yInset = yInset;
-			}
+		getYInset(this: Chart<ChartState>) {
+			const { xInset = this.yInset || 0 } = this.state;
+			return xInset;
 		},
 
 		getChildrenNodes(): VNode[] {
 			// Subclasses must override.
 			return [];
-		}
-	})
-	.mixin({
-		initialize(instance: Chart<ChartState>, { xInset = 0, yInset = 0 }: ChartOptions<ChartState> = {}) {
-			privateStateMap.set(instance, { xInset, yInset });
 		}
 	});
 

--- a/src/render/createChart.ts
+++ b/src/render/createChart.ts
@@ -61,46 +61,42 @@ const shadowYInsets = new WeakMap<Chart<ChartState>, number>();
 
 const createChart: ChartFactory = createWidget
 	.mixin(createSvgRootMixin)
-	.mixin({
-		mixin: <ChartMixin> {
-			get xInset(this: Chart<ChartState>) {
-				const { xInset = shadowXInsets.get(this) } = this.state || {};
-				return xInset;
-			},
+	.extend({
+		get xInset(this: Chart<ChartState>) {
+			const { xInset = shadowXInsets.get(this) } = this.state || {};
+			return xInset;
+		},
 
-			set xInset(xInset) {
-				if (this.state) {
-					this.setState({ xInset });
-				}
-				else {
-					shadowXInsets.set(this, xInset);
-				}
-			},
-
-			get yInset(this: Chart<ChartState>) {
-				const { yInset = shadowYInsets.get(this) } = this.state || {};
-				return yInset;
-			},
-
-			set yInset(yInset) {
-				if (this.state) {
-					this.setState({ yInset });
-				}
-				else {
-					shadowYInsets.set(this, yInset);
-				}
-			},
-
-			getChildrenNodes(): VNode[] {
-				// Subclasses must override.
-				return [];
+		set xInset(xInset) {
+			if (this.state) {
+				this.setState({ xInset });
+			}
+			else {
+				shadowXInsets.set(this, xInset);
 			}
 		},
 
-		initialize(
-			instance: Chart<ChartState>,
-			{ xInset = 0, yInset = 0 }: ChartOptions<ChartState> = {}
-		) {
+		get yInset(this: Chart<ChartState>) {
+			const { yInset = shadowYInsets.get(this) } = this.state || {};
+			return yInset;
+		},
+
+		set yInset(yInset) {
+			if (this.state) {
+				this.setState({ yInset });
+			}
+			else {
+				shadowYInsets.set(this, yInset);
+			}
+		},
+
+		getChildrenNodes(): VNode[] {
+			// Subclasses must override.
+			return [];
+		}
+	})
+	.mixin({
+		initialize(instance: Chart<ChartState>, { xInset = 0, yInset = 0 }: ChartOptions<ChartState> = {}) {
 			shadowXInsets.set(instance, xInset);
 			shadowYInsets.set(instance, yInset);
 		}

--- a/src/render/createChart.ts
+++ b/src/render/createChart.ts
@@ -56,14 +56,18 @@ export interface ChartFactory extends ComposeFactory<
 	<S extends ChartState>(options?: ChartOptions<S>): Chart<S>;
 }
 
-const shadowXInsets = new WeakMap<Chart<ChartState>, number>();
-const shadowYInsets = new WeakMap<Chart<ChartState>, number>();
+interface PrivateState {
+	xInset: number;
+	yInset: number;
+}
+
+const privateStateMap = new WeakMap<Chart<ChartState>, PrivateState>();
 
 const createChart: ChartFactory = createWidget
 	.mixin(createSvgRootMixin)
 	.extend({
 		get xInset(this: Chart<ChartState>) {
-			const { xInset = shadowXInsets.get(this) } = this.state || {};
+			const { xInset = privateStateMap.get(this).xInset } = this.state || {};
 			return xInset;
 		},
 
@@ -72,12 +76,12 @@ const createChart: ChartFactory = createWidget
 				this.setState({ xInset });
 			}
 			else {
-				shadowXInsets.set(this, xInset);
+				privateStateMap.get(this).xInset = xInset;
 			}
 		},
 
 		get yInset(this: Chart<ChartState>) {
-			const { yInset = shadowYInsets.get(this) } = this.state || {};
+			const { yInset = privateStateMap.get(this).yInset } = this.state || {};
 			return yInset;
 		},
 
@@ -86,7 +90,7 @@ const createChart: ChartFactory = createWidget
 				this.setState({ yInset });
 			}
 			else {
-				shadowYInsets.set(this, yInset);
+				privateStateMap.get(this).yInset = yInset;
 			}
 		},
 
@@ -97,8 +101,7 @@ const createChart: ChartFactory = createWidget
 	})
 	.mixin({
 		initialize(instance: Chart<ChartState>, { xInset = 0, yInset = 0 }: ChartOptions<ChartState> = {}) {
-			shadowXInsets.set(instance, xInset);
-			shadowYInsets.set(instance, yInset);
+			privateStateMap.set(instance, { xInset, yInset });
 		}
 	});
 

--- a/src/render/createColumnChart.ts
+++ b/src/render/createColumnChart.ts
@@ -55,7 +55,9 @@ const createColumnChart: ColumnChartFactory<any> = createChart
 				return [];
 			}
 
-			const { domain, xInset, yInset } = this;
+			const domain = this.getDomain();
+			const xInset = this.getXInset();
+			const yInset = this.getYInset();
 			const nodes: VNode[] = [];
 
 			const axes = this.createAxes(plot, domain);

--- a/src/render/createGroupedColumnChart.ts
+++ b/src/render/createGroupedColumnChart.ts
@@ -104,24 +104,23 @@ const shadowGroupSpacings = new WeakMap<GroupedColumnChart<any, any, any, Groupe
 // Cast to a generic factory so subclasses can modify the datum type.
 // The factory should be casted to GroupedColumnChartFactory when creating a grouped column chart.
 const createGroupedColumnChart: GroupedColumnChartFactory<any, any> = createColumnChart
-	.mixin({
-		mixin: {
-			get groupSpacing(this: GroupedColumnChart<any, any, any, GroupedColumnChartState<any>>) {
-				const { groupSpacing = shadowGroupSpacings.get(this) } = this.state || {};
-				return groupSpacing;
-			},
-
-			set groupSpacing(groupSpacing) {
-				if (this.state) {
-					this.setState({ groupSpacing });
-				}
-				else {
-					shadowGroupSpacings.set(this, groupSpacing);
-				}
-				this.invalidate();
-			}
+	.extend({
+		get groupSpacing(this: GroupedColumnChart<any, any, any, GroupedColumnChartState<any>>) {
+			const { groupSpacing = shadowGroupSpacings.get(this) } = this.state || {};
+			return groupSpacing;
 		},
 
+		set groupSpacing(groupSpacing) {
+			if (this.state) {
+				this.setState({ groupSpacing });
+			}
+			else {
+				shadowGroupSpacings.set(this, groupSpacing);
+			}
+			this.invalidate();
+		}
+	})
+	.mixin({
 		aspectAdvice: {
 			after: {
 				plot<G, T>(this: GroupedColumnChart<G, T, GroupedColumn<G, T>, any>, {
@@ -222,9 +221,8 @@ const createGroupedColumnChart: GroupedColumnChartFactory<any, any> = createColu
 					};
 				}
 			}
-		}
-	})
-	.mixin({
+		},
+
 		initialize<G, T>(
 			instance: GroupedColumnChart<G, T, GroupedColumn<G, T>, GroupedColumnChartState<T>>,
 			{

--- a/src/render/createGroupedColumnChart.ts
+++ b/src/render/createGroupedColumnChart.ts
@@ -95,7 +95,10 @@ export interface GroupedColumnChartFactory<G, T> extends ComposeFactory<
 	): GroupedColumnChart<G, T, GroupedColumn<G, T>, GroupedColumnChartState<T>>;
 }
 
-const groupSelectors = new WeakMap<GroupedColumnChart<any, any, any, GroupedColumnChartState<any>>, GroupSelector<any, any>>();
+const groupSelectors = new WeakMap<
+	GroupedColumnChart<any, any, any, GroupedColumnChartState<any>>,
+	GroupSelector<any, any>
+>();
 const shadowGroupSpacings = new WeakMap<GroupedColumnChart<any, any, any, GroupedColumnChartState<any>>, number>();
 
 // Cast to a generic factory so subclasses can modify the datum type.
@@ -171,11 +174,8 @@ const createGroupedColumnChart: GroupedColumnChartFactory<any, any> = createColu
 					}
 
 					let chartWidth = 0;
-					const points = from<
-						[G, Record],
-						GroupedColumnPoint<G, T>
-					>(groups.entries(), (entry, index) => {
-						const [group, { columnPoints, columns, totalValue, value, y1 }] = entry;
+					const points = from<[ G, Record ], GroupedColumnPoint<G, T>>(groups.entries(), (entry, index) => {
+						const [ group, { columnPoints, columns, totalValue, value, y1 } ] = entry;
 
 						const x1 = chartWidth;
 

--- a/src/render/createStackedColumnChart.ts
+++ b/src/render/createStackedColumnChart.ts
@@ -88,7 +88,10 @@ export interface StackedColumnChartFactory<G, T> extends ComposeFactory<
 	): StackedColumnChart<G, T, StackedColumn<G, T>, StackedColumnChartState<T>>;
 }
 
-const stackSelectors = new WeakMap<StackedColumnChart<any, any, any, StackedColumnChartState<any>>, StackSelector<any, any>>();
+const stackSelectors = new WeakMap<
+	StackedColumnChart<any, any, any, StackedColumnChartState<any>>,
+	StackSelector<any, any>
+>();
 const shadowStackSpacings = new WeakMap<StackedColumnChart<any, any, any, StackedColumnChartState<any>>, number>();
 
 // Cast to a generic factory so subclasses can modify the datum type.
@@ -126,7 +129,7 @@ const createStackedColumnChart: StackedColumnChartFactory<any, any> = createColu
 						columnHeight,
 						columnSpacing,
 						columnWidth,
-						domain: [domainMin, domainMax],
+						domain: [ domainMin, domainMax ],
 						stackSpacing
 					} = this;
 
@@ -143,8 +146,8 @@ const createStackedColumnChart: StackedColumnChartFactory<any, any> = createColu
 						relativeValue: number;
 						value: number;
 					}
-					const stacks = new Map<G, [Record, Record]>();
-					const createSigned = (): [Record, Record] => {
+					const stacks = new Map<G, [ Record, Record ]>();
+					const createSigned = (): [ Record, Record ] => {
 						return [
 							// Record negative and positive columns separately.
 							{ columnPoints: [], columns: [], isNegative: true, relativeValue: 0, value: 0 },
@@ -257,10 +260,10 @@ const createStackedColumnChart: StackedColumnChartFactory<any, any> = createColu
 
 					let chartWidth = 0;
 					const points = from<
-						[G, [Record, Record]],
+						[ G, [ Record, Record ] ],
 						StackedColumnPoint<G, T>
 					>(stacks.entries(), (entry, index) => {
-						const [stack, signed] = <[G, [Record, Record]]> entry;
+						const [ stack, signed ] = <[ G, [ Record, Record ] ]> entry;
 
 						const value = signed[0].value + signed[1].value;
 						const columns = signed[0].columns.concat(signed[1].columns);
@@ -285,7 +288,7 @@ const createStackedColumnChart: StackedColumnChartFactory<any, any> = createColu
 							const stackHeight = availableHeight * relativeValue * correction;
 
 							let prev = { displayHeight: 0, y1: positiveHeight, y2: negativeOffset };
-							const [firstPoint] = columnPoints;
+							const [ firstPoint ] = columnPoints;
 							for (const point of columnPoints) {
 								// Ensure each column within the stack has the correct size relative to the other
 								// columns.

--- a/src/render/createStackedColumnChart.ts
+++ b/src/render/createStackedColumnChart.ts
@@ -97,24 +97,23 @@ const shadowStackSpacings = new WeakMap<StackedColumnChart<any, any, any, Stacke
 // Cast to a generic factory so subclasses can modify the datum type.
 // The factory should be casted to StackedColumnChartFactory when creating a stacked column chart.
 const createStackedColumnChart: StackedColumnChartFactory<any, any> = createColumnChart
-	.mixin({
-		mixin: {
-			get stackSpacing(this: StackedColumnChart<any, any, any, StackedColumnChartState<any>>) {
-				const { stackSpacing = shadowStackSpacings.get(this) } = this.state || {};
-				return stackSpacing;
-			},
-
-			set stackSpacing(stackSpacing) {
-				if (this.state) {
-					this.setState({ stackSpacing });
-				}
-				else {
-					shadowStackSpacings.set(this, stackSpacing);
-				}
-				this.invalidate();
-			}
+	.extend({
+		get stackSpacing(this: StackedColumnChart<any, any, any, StackedColumnChartState<any>>) {
+			const { stackSpacing = shadowStackSpacings.get(this) } = this.state || {};
+			return stackSpacing;
 		},
 
+		set stackSpacing(stackSpacing) {
+			if (this.state) {
+				this.setState({ stackSpacing });
+			}
+			else {
+				shadowStackSpacings.set(this, stackSpacing);
+			}
+			this.invalidate();
+		}
+	})
+	.mixin({
 		aspectAdvice: {
 			after: {
 				plot<G, T>(this: StackedColumnChart<G, T, StackedColumn<G, T>, any>, {
@@ -365,9 +364,8 @@ const createStackedColumnChart: StackedColumnChartFactory<any, any> = createColu
 					};
 				}
 			}
-		}
-	})
-	.mixin({
+		},
+
 		initialize<G, T>(
 			instance: StackedColumnChart<G, T, StackedColumn<G, T>, StackedColumnChartState<T>>,
 			{

--- a/src/render/createStackedColumnChart.ts
+++ b/src/render/createStackedColumnChart.ts
@@ -261,7 +261,7 @@ const createStackedColumnChart: StackedColumnChartFactory<any, any> = createColu
 						[ G, [ Record, Record ] ],
 						StackedColumnPoint<G, T>
 					>(stacks.entries(), (entry, index) => {
-						const [ stack, signed ] = <[ G, [ Record, Record ] ]> entry;
+						const [ stack, signed ] = entry;
 
 						const value = signed[0].value + signed[1].value;
 						const columns = signed[0].columns.concat(signed[1].columns);

--- a/src/render/interfaces.ts
+++ b/src/render/interfaces.ts
@@ -36,12 +36,12 @@ export enum Values { None = 0b00, Positive = 0b01, Negative = 0b10, Both = 0b11 
  * Describes multiple plotted points and properties of the resulting chart.
  */
 export interface Plot<P extends Point<any>> {
-	height: number;
-	horizontalValues: Values;
-	points: P[];
-	verticalValues: Values;
-	width: number;
-	zero: { x: number, y: number };
+	readonly height: number;
+	readonly horizontalValues: Values;
+	readonly points: P[];
+	readonly verticalValues: Values;
+	readonly width: number;
+	readonly zero: { x: number, y: number };
 }
 
 /**
@@ -56,25 +56,25 @@ export interface Point<D extends Datum<any>> {
 	/**
 	 * Datum represented by the point.
 	 */
-	datum: D;
+	readonly datum: D;
 
 	/**
 	 * Horizontal start position.
 	 */
-	x1: number;
+	readonly x1: number;
 
 	/**
 	 * Horizontal end position.
 	 */
-	x2: number;
+	readonly x2: number;
 
 	/**
 	 * Vertical start position.
 	 */
-	y1: number;
+	readonly y1: number;
 
 	/**
 	 * Vertical end position.
 	 */
-	y2: number;
+	readonly y2: number;
 }

--- a/src/render/interfaces.ts
+++ b/src/render/interfaces.ts
@@ -6,17 +6,17 @@ import { Datum } from '../data/interfaces';
  * The first number is the minimum value, which must be less than or equal to zero.
  * The second number is the maximum value, which must be greater than or equal to zero.
  *
- * When [0, 0] no limit applies.
+ * When [ 0, 0 ] no limit applies.
  *
- * For example for a column chart, [0, 50] means inputs with value=50 are plotted with the full column height.
+ * For example for a column chart, [ 0, 50 ] means inputs with value=50 are plotted with the full column height.
  */
-export type Domain = [number, number];
+export type Domain = [ number, number ];
 
 /**
  * Option for defining a domain.
  *
- * If just a number, and less than zero, the resulting domain will be [number, 0]. If greater than zero it'll be
- * [0, number]. Otherwise the domain will be [0, 0].
+ * If just a number, and less than zero, the resulting domain will be [ number, 0 ]. If greater than zero it'll be
+ * [ 0, number ]. Otherwise the domain will be [ 0, 0 ].
  */
 export type DomainOption = number | Domain;
 

--- a/src/render/mixins/createAxesMixin.ts
+++ b/src/render/mixins/createAxesMixin.ts
@@ -332,74 +332,74 @@ export interface AxesFactory<D extends Datum<any>> extends ComposeFactory<
 	<D extends Datum<any>>(options?: AxesOptions<D>): Axes<D>;
 }
 
-interface AxesConfiguration<D> {
-	bottom?: AxisConfiguration<D>;
-	left?: AxisConfiguration<D>;
-	right?: AxisConfiguration<D>;
-	top?: AxisConfiguration<D>;
+interface PrivateState {
+	bottom?: AxisConfiguration<any>;
+	left?: AxisConfiguration<any>;
+	right?: AxisConfiguration<any>;
+	top?: AxisConfiguration<any>;
 }
 
-const shadowConfiguration = new WeakMap<Axes<any>, AxesConfiguration<any>>();
+const privateStateMap = new WeakMap<Axes<any>, PrivateState>();
 
 const createAxes: AxesFactory<any> = compose({
 	get bottomAxis(this: Axes<any>) {
-		const { bottom } = shadowConfiguration.get(this);
+		const { bottom } = privateStateMap.get(this);
 		if (bottom) {
 			return bottom;
 		}
 	},
 
 	set bottomAxis(axis: AxisConfiguration<any>) {
-		shadowConfiguration.get(this).bottom = axis;
+		privateStateMap.get(this).bottom = axis;
 		// invalidate() is typed as being optional, but that's just a workaround until
 		// <https://github.com/dojo/compose/issues/74> is in place. Silence the strict null check violation for now.
 		this.invalidate!();
 	},
 
 	get leftAxis(this: Axes<any>) {
-		const { left } = shadowConfiguration.get(this);
+		const { left } = privateStateMap.get(this);
 		if (left) {
 			return left;
 		}
 	},
 
 	set leftAxis(axis: AxisConfiguration<any>) {
-		shadowConfiguration.get(this).left = axis;
+		privateStateMap.get(this).left = axis;
 		// invalidate() is typed as being optional, but that's just a workaround until
 		// <https://github.com/dojo/compose/issues/74> is in place. Silence the strict null check violation for now.
 		this.invalidate!();
 	},
 
 	get rightAxis(this: Axes<any>) {
-		const { right } = shadowConfiguration.get(this);
+		const { right } = privateStateMap.get(this);
 		if (right) {
 			return right;
 		}
 	},
 
 	set rightAxis(axis: AxisConfiguration<any>) {
-		shadowConfiguration.get(this).right = axis;
+		privateStateMap.get(this).right = axis;
 		// invalidate() is typed as being optional, but that's just a workaround until
 		// <https://github.com/dojo/compose/issues/74> is in place. Silence the strict null check violation for now.
 		this.invalidate!();
 	},
 
 	get topAxis(this: Axes<any>) {
-		const { top } = shadowConfiguration.get(this);
+		const { top } = privateStateMap.get(this);
 		if (top) {
 			return top;
 		}
 	},
 
 	set topAxis(axis: AxisConfiguration<any>) {
-		shadowConfiguration.get(this).top = axis;
+		privateStateMap.get(this).top = axis;
 		// invalidate() is typed as being optional, but that's just a workaround until
 		// <https://github.com/dojo/compose/issues/74> is in place. Silence the strict null check violation for now.
 		this.invalidate!();
 	},
 
 	createAxes<D extends Datum<any>>(this: Axes<D>, plot: Plot<Point<D>>, domain: Domain): CreatedAxes {
-		const configuration = shadowConfiguration.get(this);
+		const configuration = privateStateMap.get(this);
 
 		const result: CreatedAxes = {
 			extraHeight: 0,
@@ -870,21 +870,21 @@ const createAxes: AxesFactory<any> = compose({
 			topAxis
 		}: AxesOptions<D> = {}
 	) {
-		const configuration: AxesConfiguration<D> = {};
+		const state: PrivateState = {};
 		if (bottomAxis) {
-			configuration.bottom = bottomAxis;
+			state.bottom = bottomAxis;
 		}
 		if (leftAxis) {
-			configuration.left = leftAxis;
+			state.left = leftAxis;
 		}
 		if (rightAxis) {
-			configuration.right = rightAxis;
+			state.right = rightAxis;
 		}
 		if (topAxis) {
-			configuration.top = topAxis;
+			state.top = topAxis;
 		}
 
-		shadowConfiguration.set(instance, configuration);
+		privateStateMap.set(instance, state);
 	}
 });
 

--- a/src/render/mixins/createAxesMixin.ts
+++ b/src/render/mixins/createAxesMixin.ts
@@ -341,7 +341,7 @@ interface AxesConfiguration<D> {
 
 const shadowConfiguration = new WeakMap<Axes<any>, AxesConfiguration<any>>();
 
-const createAxes: AxesFactory<any> = compose(<AxesMixin<any>> {
+const createAxes: AxesFactory<any> = compose({
 	get bottomAxis(this: Axes<any>) {
 		const { bottom } = shadowConfiguration.get(this);
 		if (bottom) {

--- a/src/render/mixins/createAxesMixin.ts
+++ b/src/render/mixins/createAxesMixin.ts
@@ -137,7 +137,7 @@ export interface HardcodedAxis extends SharedConfiguration {
 	 *
 	 * By default no label is shown, however you can provide tuples of marking numbers and label strings.
 	 */
-	hardcoded: number[] | [number, string][];
+	hardcoded: number[] | [ number, string ][];
 }
 
 export function isHardcoded(cfg: AxisConfiguration<any>): cfg is HardcodedAxis {
@@ -177,8 +177,8 @@ export interface RangeBasedAxis extends SharedConfiguration {
 		/**
 		 * Whether the axis should be fixed to the end of the chart (in the direction of the axis).
 		 *
-		 * Defaults to `false`, in which case the axis is scaled proportionally to the size of the chart in order to show
-		 * the range.
+		 * Defaults to `false`, in which case the axis is scaled proportionally to the size of the chart in order to
+		 * show the range.
 		 */
 		fixed?: boolean;
 
@@ -264,7 +264,7 @@ export interface AxesMixin<D extends Datum<any>> {
 
 	createAxes(plot: Plot<Point<D>>, domain: Domain): CreatedAxes;
 
-	createAxis(cfg: AxisConfiguration<D>, side: Side, plot: Plot<Point<D>>, domain: Domain): [VNode[], number];
+	createAxis(cfg: AxisConfiguration<D>, side: Side, plot: Plot<Point<D>>, domain: Domain): [ VNode[], number ];
 
 	createAxisLabel(
 		cfg: LabelConfiguration,
@@ -320,7 +320,7 @@ export interface AxesMixin<D extends Datum<any>> {
 		domain: Domain,
 		labels?: LabelConfiguration,
 		ticks?: TickConfiguration
-	): [VNode[], number];
+	): [ VNode[], number ];
 }
 
 export type Axes<D extends Datum<any>> = Invalidatable & AxesMixin<D>;
@@ -407,22 +407,22 @@ const createAxes: AxesFactory<any> = compose(<AxesMixin<any>> {
 		};
 
 		if (configuration.bottom) {
-			const [nodes, extra] = this.createAxis(configuration.bottom, 'bottom', plot, domain);
+			const [ nodes, extra ] = this.createAxis(configuration.bottom, 'bottom', plot, domain);
 			result.bottom = nodes;
 			result.extraWidth = Math.max(result.extraWidth, extra);
 		}
 		if (configuration.left) {
-			const [nodes, extra] = this.createAxis(configuration.left, 'left', plot, domain);
+			const [ nodes, extra ] = this.createAxis(configuration.left, 'left', plot, domain);
 			result.left = nodes;
 			result.extraHeight = Math.max(result.extraHeight, extra);
 		}
 		if (configuration.right) {
-			const [nodes, extra] = this.createAxis(configuration.right, 'right', plot, domain);
+			const [ nodes, extra ] = this.createAxis(configuration.right, 'right', plot, domain);
 			result.right = nodes;
 			result.extraHeight = Math.max(result.extraHeight, extra);
 		}
 		if (configuration.top) {
-			const [nodes, extra] = this.createAxis(configuration.top, 'top', plot, domain);
+			const [ nodes, extra ] = this.createAxis(configuration.top, 'top', plot, domain);
 			result.top = nodes;
 			result.extraWidth = Math.max(result.extraWidth, extra);
 		}
@@ -435,7 +435,7 @@ const createAxes: AxesFactory<any> = compose(<AxesMixin<any>> {
 		side: Side,
 		plot: Plot<Point<D>>,
 		domain: Domain
-	): [VNode[], number] {
+	): [ VNode[], number ] {
 		const { gridLines, ticks } = cfg;
 		const { height, width, zero } = plot;
 
@@ -487,7 +487,9 @@ const createAxes: AxesFactory<any> = compose(<AxesMixin<any>> {
 		}
 		else if (isRangeBased(cfg)) {
 			let stepNodes: VNode[];
-			[stepNodes, extraSpace] = this.createRangeBasedAxis(cfg, gridLineLength, side, plot, domain, labels, ticks);
+			[ stepNodes, extraSpace ] = this.createRangeBasedAxis(
+				cfg, gridLineLength, side, plot, domain, labels, ticks
+			);
 			nodes.push(...stepNodes);
 		}
 
@@ -496,7 +498,7 @@ const createAxes: AxesFactory<any> = compose(<AxesMixin<any>> {
 			extraSpace = Math.max(extraSpace, gridLineLength - chartSize);
 		}
 
-		return [nodes, extraSpace];
+		return [ nodes, extraSpace ];
 	},
 
 	createAxisGridLine(length: number, side: Side, index: number, x1: number, y1: number) {
@@ -679,7 +681,7 @@ const createAxes: AxesFactory<any> = compose(<AxesMixin<any>> {
 			let relative: number;
 			let text = '';
 			if (Array.isArray(marking)) {
-				[relative, text] = marking;
+				[ relative, text ] = marking;
 			}
 			else {
 				relative = marking;
@@ -773,7 +775,7 @@ const createAxes: AxesFactory<any> = compose(<AxesMixin<any>> {
 			width,
 			zero
 		}: Plot<Point<D>>,
-		[domainMin, domainMax]: Domain,
+		[ domainMin, domainMax ]: Domain,
 		labels?: LabelConfiguration,
 		ticks?: TickConfiguration
 	) {
@@ -787,7 +789,7 @@ const createAxes: AxesFactory<any> = compose(<AxesMixin<any>> {
 
 		let mostNegativeValue = domainMin;
 		let mostPositiveValue = domainMax;
-		// [0, 0] domains should be ignored.
+		// [ 0, 0 ] domains should be ignored.
 		if (domainMin === 0 && domainMax === 0) {
 			for (const { datum: { value } } of points) {
 				if (value < mostNegativeValue) {
@@ -856,7 +858,7 @@ const createAxes: AxesFactory<any> = compose(<AxesMixin<any>> {
 			prev = p;
 		}
 
-		return [nodes, extraSpace];
+		return [ nodes, extraSpace ];
 	}
 }).mixin({
 	initialize<D extends Datum<any>>(

--- a/src/render/mixins/createAxesMixin.ts
+++ b/src/render/mixins/createAxesMixin.ts
@@ -529,7 +529,7 @@ const createAxes: AxesFactory<any> = compose(<AxesMixin<any>> {
 
 	createAxisLabel(
 		{
-			anchor = <Anchor> 'middle',
+			anchor = 'middle',
 			dominantBaseline,
 			offset = 0,
 			rotation = 0,
@@ -601,7 +601,7 @@ const createAxes: AxesFactory<any> = compose(<AxesMixin<any>> {
 
 	createAxisTick(
 		{
-			anchor = <Anchor> 'middle',
+			anchor = 'middle',
 			length,
 			offset = 0
 		}: TickConfiguration,

--- a/src/render/mixins/createColumnPlotMixin.ts
+++ b/src/render/mixins/createColumnPlotMixin.ts
@@ -381,7 +381,7 @@ const createColumnPlot: ColumnPlotFactory<any> = compose({
 			columnHeight = 0,
 			columnSpacing = 0,
 			columnWidth = 0,
-			domain = [ 0, 0 ] as Domain,
+			domain = [ 0, 0 ],
 			divisorOperator,
 			valueSelector
 		}: ColumnPlotOptions<T, ColumnPlotState<T>> = {}

--- a/src/render/mixins/createColumnPlotMixin.ts
+++ b/src/render/mixins/createColumnPlotMixin.ts
@@ -21,9 +21,9 @@ function normalizeDomain(domain: DomainOption): Domain {
 }
 
 export interface ColumnPoint<T> extends Point<Column<T>> {
-	displayHeight: number;
-	displayWidth: number;
-	offsetLeft: number;
+	readonly displayHeight: number;
+	readonly displayWidth: number;
+	readonly offsetLeft: number;
 }
 
 export interface ColumnPointPlot<T> extends Plot<ColumnPoint<T>> {}
@@ -124,7 +124,7 @@ export interface ColumnPlotMixin<T> {
 	 * Can be overriden by specifying a `divisorOperator()` option. If neither is available a static divisor of `1`
 	 * will be used.
 	 */
-	divisorOperator?: DivisorOperator<T>;
+	readonly divisorOperator?: DivisorOperator<T>;
 
 	/**
 	 * Controls the range for which values are plotted with the full columnHeight. The height is distributed across the
@@ -139,7 +139,7 @@ export interface ColumnPlotMixin<T> {
 	 * Can be overriden by specifying a `valueSelector()` option. If neither is available all values will be hardcoded
 	 * to `0`.
 	 */
-	valueSelector?: ValueSelector<T>;
+	readonly valueSelector?: ValueSelector<T>;
 
 	/**
 	 * Plot "points" for each column.

--- a/src/render/mixins/createColumnPlotMixin.ts
+++ b/src/render/mixins/createColumnPlotMixin.ts
@@ -17,7 +17,7 @@ import createInputSeries, {
 export { Column };
 
 function normalizeDomain(domain: DomainOption): Domain {
-	return Array.isArray(domain) ? domain : [domain < 0 ? domain : 0, domain > 0 ? domain : 0];
+	return Array.isArray(domain) ? domain : [ domain < 0 ? domain : 0, domain > 0 ? domain : 0 ];
 }
 
 export interface ColumnPoint<T> extends Point<Column<T>> {
@@ -49,9 +49,9 @@ export interface ColumnPlotState<T> extends InputSeriesState<T> {
 	 * negative and positive values commensurate with the range. Any input values that exceed the minimum or maximum
 	 * will still be plotted proportionally (but exceeding the height limits).
 	 *
-	 * If a single number is provided, if that number is greater than zero it implies a domain of [0, number]. If it's
-	 * less than zero it implies a domain of [number, 0]. If zero it implies there are no minimum or maximum values,
-	 * same for a domain of [0, 0].
+	 * If a single number is provided, if that number is greater than zero it implies a domain of [ 0, number ]. If it's
+	 * less than zero it implies a domain of [ number, 0 ]. If zero it implies there are no minimum or maximum values,
+	 * same for a domain of [ 0, 0 ].
 	 */
 	domain?: DomainOption;
 }
@@ -86,9 +86,9 @@ export interface ColumnPlotOptions<T, S extends ColumnPlotState<T>> extends Inpu
 	 * negative and positive values commensurate with the range. Any input values that exceed the minimum or maximum
 	 * will still be plotted proportionally (but exceeding the height limits).
 	 *
-	 * If a single number is provided, if that number is greater than zero it implies a domain of [0, number]. If it's
-	 * less than zero it implies a domain of [number, 0]. If zero it implies there are no minimum or maximum values,
-	 * same for a domain of [0, 0].
+	 * If a single number is provided, if that number is greater than zero it implies a domain of [ 0, number ]. If it's
+	 * less than zero it implies a domain of [ number, 0 ]. If zero it implies there are no minimum or maximum values,
+	 * same for a domain of [ 0, 0 ].
 	 */
 	domain?: DomainOption;
 
@@ -242,7 +242,7 @@ const createColumnPlot: ColumnPlotFactory<any> = compose({
 
 	plot<T>(this: ColumnPlot<T, ColumnPlotState<T>>): ColumnPointPlot<T> {
 		const series = columnSeries.get(this);
-		const { columnHeight, columnSpacing, columnWidth: displayWidth, domain: [domainMin, domainMax] } = this;
+		const { columnHeight, columnSpacing, columnWidth: displayWidth, domain: [ domainMin, domainMax ] } = this;
 
 		let mostNegativeRelValue = 0;
 		let mostNegativeValue = 0;
@@ -381,7 +381,7 @@ const createColumnPlot: ColumnPlotFactory<any> = compose({
 			columnHeight = 0,
 			columnSpacing = 0,
 			columnWidth = 0,
-			domain = [0, 0] as Domain,
+			domain = [ 0, 0 ] as Domain,
 			divisorOperator,
 			valueSelector
 		}: ColumnPlotOptions<T, ColumnPlotState<T>> = {}

--- a/src/render/mixins/createInputSeriesMixin.ts
+++ b/src/render/mixins/createInputSeriesMixin.ts
@@ -77,16 +77,19 @@ const createInputSeries: InputSeriesFactory<any> = createStateful
 	.mixin({
 		mixin: createEvented,
 
-		initialize<T>(instance: InputSeries<T, InputSeriesState<T>>, { inputSeries }: InputSeriesOptions<T, InputSeriesState<T>> = {}) {
+		initialize<T>(
+			instance: InputSeries<T, InputSeriesState<T>>,
+			{ inputSeries }: InputSeriesOptions<T, InputSeriesState<T>> = {}
+		) {
 			if (inputSeries) {
 				// Create an observable if the data option was provided.
 				let observable: Observable<T[]>;
 				if (isArrayLike(inputSeries)) {
-					observable = Observable.from([from(inputSeries)]);
+					observable = Observable.from([ from(inputSeries) ]);
 				}
 				else if (isIterable(inputSeries)) {
 					// The repetition is a workaround for <https://github.com/dojo/shim/issues/9>.
-					observable = Observable.from([from(inputSeries)]);
+					observable = Observable.from([ from(inputSeries) ]);
 				}
 				else {
 					observable = inputSeries;

--- a/src/render/mixins/createInputSeriesMixin.ts
+++ b/src/render/mixins/createInputSeriesMixin.ts
@@ -1,5 +1,5 @@
 import { ComposeFactory } from 'dojo-compose/compose';
-import createEvented, { EventedListener, TargettedEventObject } from 'dojo-compose/mixins/createEvented';
+import { EventedListener, TargettedEventObject } from 'dojo-compose/mixins/createEvented';
 import createStateful, { State, Stateful, StatefulOptions } from 'dojo-compose/mixins/createStateful';
 import { Handle } from 'dojo-core/interfaces';
 import { from } from 'dojo-shim/array';
@@ -75,8 +75,6 @@ const createInputSeries: InputSeriesFactory<any> = createStateful
 		}
 	})
 	.mixin({
-		mixin: createEvented,
-
 		initialize<T>(
 			instance: InputSeries<T, InputSeriesState<T>>,
 			{ inputSeries }: InputSeriesOptions<T, InputSeriesState<T>> = {}

--- a/src/render/mixins/createInputSeriesMixin.ts
+++ b/src/render/mixins/createInputSeriesMixin.ts
@@ -32,7 +32,7 @@ export interface InputSeriesMixin<T> {
 	/**
 	 * Provides the current observable, if any.
 	 */
-	inputSeries?: Observable<T[]>;
+	readonly inputSeries?: Observable<T[]>;
 }
 
 /**
@@ -42,7 +42,7 @@ export interface InputSeriesChangeEvent<T> extends TargettedEventObject {
 	/**
 	 * The new observable.
 	 */
-	observable: Observable<T[]>;
+	readonly observable: Observable<T[]>;
 }
 
 export interface InputSeriesOverrides<T> {

--- a/src/render/mixins/createSvgRootMixin.ts
+++ b/src/render/mixins/createSvgRootMixin.ts
@@ -53,13 +53,17 @@ export type SvgRoot<S extends SvgRootState> = Stateful<S> & Invalidatable & SvgR
 
 export type SvgRootFactory = ComposeFactory<SvgRoot<SvgRootState>, SvgRootOptions<SvgRootState>>;
 
-const shadowHeights = new WeakMap<SvgRoot<SvgRootState>, number>();
-const shadowWidths = new WeakMap<SvgRoot<SvgRootState>, number>();
+interface PrivateState {
+	height: number;
+	width: number;
+}
+
+const privateStateMap = new WeakMap<SvgRoot<SvgRootState>, PrivateState>();
 
 const createSvgRootMixin: SvgRootFactory = createStateful
 	.extend({
 		get height(this: SvgRoot<SvgRootState>) {
-			const { height = shadowHeights.get(this) } = this.state || {};
+			const { height = privateStateMap.get(this).height } = this.state || {};
 			return height;
 		},
 
@@ -68,7 +72,7 @@ const createSvgRootMixin: SvgRootFactory = createStateful
 				this.setState({ height });
 			}
 			else {
-				shadowHeights.set(this, height);
+				privateStateMap.get(this).height = height;
 				// invalidate() is typed as being optional, but that's just a workaround until
 				// <https://github.com/dojo/compose/issues/74> is in place. Silence the strict null check violation
 				// for now.
@@ -84,7 +88,7 @@ const createSvgRootMixin: SvgRootFactory = createStateful
 		set tagName(noop) {},
 
 		get width(this: SvgRoot<SvgRootState>) {
-			const { width = shadowWidths.get(this) } = this.state || {};
+			const { width = privateStateMap.get(this).width } = this.state || {};
 			return width;
 		},
 
@@ -93,7 +97,7 @@ const createSvgRootMixin: SvgRootFactory = createStateful
 				this.setState({ width });
 			}
 			else {
-				shadowWidths.set(this, width);
+				privateStateMap.get(this).width = width;
 				// invalidate() is typed as being optional, but that's just a workaround until
 				// <https://github.com/dojo/compose/issues/74> is in place. Silence the strict null check violation
 				// for now.
@@ -113,8 +117,7 @@ const createSvgRootMixin: SvgRootFactory = createStateful
 		]
 	}).mixin({
 		initialize(instance: SvgRoot<SvgRootState>, { height = 150, width = 300 }: SvgRootOptions<SvgRootState> = {}) {
-			shadowHeights.set(instance, height);
-			shadowWidths.set(instance, width);
+			privateStateMap.set(instance, { height, width });
 		}
 	});
 

--- a/src/render/mixins/createSvgRootMixin.ts
+++ b/src/render/mixins/createSvgRootMixin.ts
@@ -38,7 +38,7 @@ export interface SvgRootMixin {
 	/**
 	 * The tagName is *always* 'svg'.
 	 */
-	tagName: string;
+	readonly tagName: string;
 
 	/**
 	 * Controls the width of the <svg> element.
@@ -86,6 +86,7 @@ const createSvgRootMixin: SvgRootFactory = createStateful
 				return 'svg';
 			},
 
+			// Other mixins may not realize they shouldn't be setting tagName.
 			set tagName(noop) {},
 
 			get width(this: SvgRoot<SvgRootState>) {

--- a/src/render/mixins/createSvgRootMixin.ts
+++ b/src/render/mixins/createSvgRootMixin.ts
@@ -57,63 +57,61 @@ const shadowHeights = new WeakMap<SvgRoot<SvgRootState>, number>();
 const shadowWidths = new WeakMap<SvgRoot<SvgRootState>, number>();
 
 const createSvgRootMixin: SvgRootFactory = createStateful
-	.mixin({
-		mixin: <SvgRootMixin> {
-			get height(this: SvgRoot<SvgRootState>) {
-				const { height = shadowHeights.get(this) } = this.state || {};
-				return height;
-			},
-
-			set height(height) {
-				if (this.state) {
-					this.setState({ height });
-				}
-				else {
-					shadowHeights.set(this, height);
-					// invalidate() is typed as being optional, but that's just a workaround until
-					// <https://github.com/dojo/compose/issues/74> is in place. Silence the strict null check violation
-					// for now.
-					this.invalidate!();
-				}
-			},
-
-			get tagName() {
-				return 'svg';
-			},
-
-			// Other mixins may not realize they shouldn't be setting tagName.
-			set tagName(noop) {},
-
-			get width(this: SvgRoot<SvgRootState>) {
-				const { width = shadowWidths.get(this) } = this.state || {};
-				return width;
-			},
-
-			set width(width) {
-				if (this.state) {
-					this.setState({ width });
-				}
-				else {
-					shadowWidths.set(this, width);
-					// invalidate() is typed as being optional, but that's just a workaround until
-					// <https://github.com/dojo/compose/issues/74> is in place. Silence the strict null check violation
-					// for now.
-					this.invalidate!();
-				}
-			},
-
-			nodeAttributes: [
-				function(this: SvgRoot<SvgRootState>): VNodeProperties {
-					const { height, width } = this;
-					return {
-						height: String(height),
-						width: String(width),
-						'shape-rendering': 'crispEdges'
-					};
-				}
-			]
+	.extend({
+		get height(this: SvgRoot<SvgRootState>) {
+			const { height = shadowHeights.get(this) } = this.state || {};
+			return height;
 		},
 
+		set height(height) {
+			if (this.state) {
+				this.setState({ height });
+			}
+			else {
+				shadowHeights.set(this, height);
+				// invalidate() is typed as being optional, but that's just a workaround until
+				// <https://github.com/dojo/compose/issues/74> is in place. Silence the strict null check violation
+				// for now.
+				this.invalidate!();
+			}
+		},
+
+		get tagName() {
+			return 'svg';
+		},
+
+		// Other mixins may not realize they shouldn't be setting tagName.
+		set tagName(noop) {},
+
+		get width(this: SvgRoot<SvgRootState>) {
+			const { width = shadowWidths.get(this) } = this.state || {};
+			return width;
+		},
+
+		set width(width) {
+			if (this.state) {
+				this.setState({ width });
+			}
+			else {
+				shadowWidths.set(this, width);
+				// invalidate() is typed as being optional, but that's just a workaround until
+				// <https://github.com/dojo/compose/issues/74> is in place. Silence the strict null check violation
+				// for now.
+				this.invalidate!();
+			}
+		},
+
+		nodeAttributes: [
+			function(this: SvgRoot<SvgRootState>): VNodeProperties {
+				const { height, width } = this;
+				return {
+					height: String(height),
+					width: String(width),
+					'shape-rendering': 'crispEdges'
+				};
+			}
+		]
+	}).mixin({
 		initialize(instance: SvgRoot<SvgRootState>, { height = 150, width = 300 }: SvgRootOptions<SvgRootState> = {}) {
 			shadowHeights.set(instance, height);
 			shadowWidths.set(instance, width);

--- a/src/render/mixins/createSvgRootMixin.ts
+++ b/src/render/mixins/createSvgRootMixin.ts
@@ -44,11 +44,6 @@ export interface SvgRootMixin {
 	 * Controls the width of the <svg> element.
 	 */
 	width?: number;
-
-	/**
-	 * Get attributes that should be used to create the root VNode.
-	 */
-	getRootAttributes(): VNodeProperties;
 }
 
 /**
@@ -107,14 +102,16 @@ const createSvgRootMixin: SvgRootFactory = createStateful
 				}
 			},
 
-			getRootAttributes(this: SvgRoot<SvgRootState>): VNodeProperties {
-				const { height, width } = this;
-				return {
-					height: String(height),
-					width: String(width),
-					'shape-rendering': 'crispEdges'
-				};
-			}
+			nodeAttributes: [
+				function(this: SvgRoot<SvgRootState>): VNodeProperties {
+					const { height, width } = this;
+					return {
+						height: String(height),
+						width: String(width),
+						'shape-rendering': 'crispEdges'
+					};
+				}
+			]
 		},
 
 		initialize(instance: SvgRoot<SvgRootState>, { height = 150, width = 300 }: SvgRootOptions<SvgRootState> = {}) {


### PR DESCRIPTION
See commits.

Note in particular the `Simplify how sizes and domains are configure` commit. This tries to follow the intent of https://github.com/dojo/widgets/issues/46 by removing various size and domain options and instance-level setters. Instead defaults can be provided on the prototype, or else the values need to be in the `state`.

This leaves support for providing selector functions and observable values in the options. These cannot be provided in the `state`. Removing that support would require chart constructors to be extended before a widget can be created, which is painful at least for one-off examples. @kitsonk any thoughts?

Note that the defaults must be provided as different properties, since the computed values are accessed through getters. This is different from how `classes` is treated with https://github.com/dojo/widgets/issues/46 since its the `nodeAttributes` function that builds the final list of `classes`.
