### PR TITLE
wip! Configure axes via class extensions

### DIFF
--- a/examples/app.ts
+++ b/examples/app.ts
@@ -6,8 +6,8 @@ import max from '../src/data/max';
 import sum from '../src/data/sum';
 import sort from '../src/data/sort';
 import createColumnChart, { ColumnChartFactory } from '../src/render/createColumnChart';
-import createGroupedColumnChart from '../src/render/createGroupedColumnChart';
-import createStackedColumnChart from '../src/render/createStackedColumnChart';
+import createGroupedColumnChart, { GroupedColumnChartFactory } from '../src/render/createGroupedColumnChart';
+import createStackedColumnChart, { StackedColumnChartFactory } from '../src/render/createStackedColumnChart';
 
 import getPlayCounts, { PlayCount } from './play-counts';
 
@@ -31,8 +31,7 @@ playCounts.subscribe((inputSeries) => {
 	store.patch({ inputSeries }, { id: 'percentageChart' });
 });
 
-const percentageChart = createColumnChart<PlayCount>({
-	id: 'percentageChart',
+const createPercentageChart: ColumnChartFactory<PlayCount> = createColumnChart.extend({
 	bottomAxis: {
 		inputs: {
 			labelSelector({ input }) { return input.artist; }
@@ -49,7 +48,11 @@ const percentageChart = createColumnChart<PlayCount>({
 		hardcoded: [[1 / 3, 'foo'], [2 / 3, 'bar'], [1, 'baz']],
 		labels: { anchor: 'end' },
 		ticks: { length: 10, zeroth: true }
-	},
+	}
+});
+
+const percentageChart = createPercentageChart({
+	id: 'percentageChart',
 	divisorOperator: sum,
 	state: {
 		height: 250,
@@ -62,17 +65,6 @@ const percentageChart = createColumnChart<PlayCount>({
 });
 
 const createAbsoluteChart: ColumnChartFactory<PlayCount> = createColumnChart.extend({
-	columnHeight: 100,
-	columnSpacing: 3,
-	columnWidth: 20,
-	domain: 35000,
-	height: 260,
-	width: 300,
-	xInset: 50,
-	yInset: 30
-});
-
-const absoluteChart = createAbsoluteChart({
 	bottomAxis: {
 		inputs: {
 			labelSelector({ input }) { return input.artist; }
@@ -80,18 +72,29 @@ const absoluteChart = createAbsoluteChart({
 		labels: { anchor: 'middle', textAnchor: 'end', rotation: -45, offset: -5 },
 		ticks: { anchor: 'end', length: 10, zeroth: true }
 	},
+	columnHeight: 100,
+	columnSpacing: 3,
+	columnWidth: 20,
+	domain: 35000,
+	height: 260,
+	width: 300,
+	xInset: 50,
+	yInset: 30,
 	leftAxis: {
 		labels: { anchor: 'end' },
 		range: { stepSize: 5000 },
 		ticks: { length: 10 }
-	},
+	}
+});
+
+const absoluteChart = createAbsoluteChart({
 	// Example of passing an observable to the chart.
 	inputSeries: playCounts,
 	divisorOperator: max,
 	valueSelector(input) { return input.count; }
 });
 
-const groupedByProvinceChart = createGroupedColumnChart<string, PlayCount>({
+const createGroupedByProvinceChart: GroupedColumnChartFactory<string, PlayCount> = createGroupedColumnChart.extend({
 	bottomAxis: {
 		inputs: {
 			labelSelector({ input }) { return input; }
@@ -112,7 +115,10 @@ const groupedByProvinceChart = createGroupedColumnChart<string, PlayCount>({
 		},
 		labels: { anchor: 'middle', textAnchor: 'end', rotation: 45, offset: -5 },
 		ticks: { anchor: 'end', length: 10, zeroth: true }
-	},
+	}
+});
+
+const groupedByProvinceChart = createGroupedByProvinceChart({
 	state: {
 		columnHeight: 100,
 		columnSpacing: 1,
@@ -131,7 +137,7 @@ const groupedByProvinceChart = createGroupedColumnChart<string, PlayCount>({
 	valueSelector(input) { return input.count; }
 });
 
-const stackedByProvinceChart = createStackedColumnChart<string, PlayCount>({
+const createStackedByProvinceChart: StackedColumnChartFactory<string, PlayCount> = createStackedColumnChart.extend({
 	bottomAxis: {
 		inputs: {
 			labelSelector({ input }) { return input; }
@@ -152,7 +158,10 @@ const stackedByProvinceChart = createStackedColumnChart<string, PlayCount>({
 		},
 		labels: { anchor: 'middle', textAnchor: 'end', rotation: 45, offset: -5 },
 		ticks: { anchor: 'end', length: 10, zeroth: true }
-	},
+	}
+});
+
+const stackedByProvinceChart = createStackedByProvinceChart({
 	state: {
 		columnHeight: 200,
 		columnSpacing: 10,

--- a/examples/axes.ts
+++ b/examples/axes.ts
@@ -1,6 +1,8 @@
 // Hey! So this file renders a variety of axis options. It's by no means exhaustive, or pretty, or even sensible given
 // for a column chart. It's just a way to visually verify some of the render logic, if you know what you're looking for.
 
+// ALSO, IT'S BROKEN NOW THAT AXES CONFIGURATION HAS BEEN MOVED OUT OF OPTIONS.
+
 import global from 'dojo-core/global';
 import { assign, deepAssign } from 'dojo-core/lang';
 import projector from 'dojo-widgets/projector';

--- a/examples/negatives.ts
+++ b/examples/negatives.ts
@@ -2,22 +2,25 @@ import global from 'dojo-core/global';
 import projector from 'dojo-widgets/projector';
 
 import max from '../src/data/max';
-import createColumnChart from '../src/render/createColumnChart';
-import createGroupedColumnChart from '../src/render/createGroupedColumnChart';
-import createStackedColumnChart from '../src/render/createStackedColumnChart';
+import createColumnChart, { ColumnChartFactory } from '../src/render/createColumnChart';
+import createGroupedColumnChart, { GroupedColumnChartFactory } from '../src/render/createGroupedColumnChart';
+import createStackedColumnChart, { StackedColumnChartFactory } from '../src/render/createStackedColumnChart';
 
-const basic = createColumnChart<number>({
+const createBasic: ColumnChartFactory<number> = createColumnChart.extend({
 	bottomAxis: {
 		inputs: true,
 		ticks: { anchor: 'end', length: 5, zeroth: true }
 	},
-	divisorOperator: max,
-	inputSeries: [-5, 5, 10],
 	leftAxis: {
 		labels: { anchor: 'end' },
 		range: { stepSize: 5 },
 		ticks: { length: 5, zeroth: true }
-	},
+	}
+});
+
+const basic = createBasic({
+	divisorOperator: max,
+	inputSeries: [-5, 5, 10],
 	state: {
 		columnHeight: 150,
 		columnSpacing: 3,
@@ -29,18 +32,21 @@ const basic = createColumnChart<number>({
 	valueSelector(input) { return input; }
 });
 
-const domain = createColumnChart<number>({
+const createDomain: ColumnChartFactory<number> = createColumnChart.extend({
 	bottomAxis: {
 		inputs: true,
 		ticks: { anchor: 'end', length: 5, zeroth: true }
 	},
-	divisorOperator: max,
-	inputSeries: [-5, 5, 10],
 	leftAxis: {
 		range: { stepSize: 5 },
 		labels: { anchor: 'end' },
 		ticks: { anchor: 'end', length: 5, zeroth: true }
-	},
+	}
+});
+
+const domain = createDomain({
+	divisorOperator: max,
+	inputSeries: [-5, 5, 10],
 	state: {
 		columnHeight: 200,
 		columnSpacing: 3,
@@ -53,20 +59,23 @@ const domain = createColumnChart<number>({
 	valueSelector(input) { return input; }
 });
 
-const allNegative = createColumnChart<number>({
+const createAllNegative: ColumnChartFactory<number> = createColumnChart.extend({
 	bottomAxis: {
 		inputs: true,
 		ticks: { anchor: 'end', length: 5, zeroth: true }
 	},
-	divisorOperator: max,
-	inputSeries: [-5, -10],
 	leftAxis: {
 		inputs: {
 			labelSelector({ input }) { return String(input); }
 		},
 		labels: { anchor: 'end' },
 		ticks: { anchor: 'end', length: 5, zeroth: true }
-	},
+	}
+});
+
+const allNegative = createAllNegative({
+	divisorOperator: max,
+	inputSeries: [-5, -10],
 	state: {
 		columnHeight: 150,
 		columnSpacing: 3,
@@ -78,18 +87,21 @@ const allNegative = createColumnChart<number>({
 	valueSelector(input) { return input; }
 });
 
-const allNegativeDomain = createColumnChart<number>({
+const createAllNegativeDomain: ColumnChartFactory<number> = createColumnChart.extend({
 	bottomAxis: {
 		inputs: true,
 		ticks: { anchor: 'end', length: 5, zeroth: true }
 	},
-	divisorOperator: max,
-	inputSeries: [-5, -10],
 	leftAxis: {
 		range: { stepSize: 5 },
 		labels: { anchor: 'end' },
 		ticks: { anchor: 'end', length: 5, zeroth: true }
-	},
+	}
+});
+
+const allNegativeDomain = createAllNegativeDomain({
+	divisorOperator: max,
+	inputSeries: [-5, -10],
 	state: {
 		columnHeight: 200,
 		columnSpacing: 3,
@@ -102,7 +114,7 @@ const allNegativeDomain = createColumnChart<number>({
 	valueSelector(input) { return input; }
 });
 
-const group = createGroupedColumnChart<string, [string, number]>({
+const createGroup: GroupedColumnChartFactory<string, [string, number]> = createGroupedColumnChart.extend({
 	bottomAxis: {
 		inputs: {
 			labelSelector({ input }) { return input; }
@@ -110,14 +122,17 @@ const group = createGroupedColumnChart<string, [string, number]>({
 		labels: { anchor: 'middle', textAnchor: 'end', rotation: -45, offset: -5 },
 		ticks: { anchor: 'end', length: 5, zeroth: true }
 	},
-	divisorOperator: max,
-	groupSelector(input) { return input[0]; },
-	inputSeries: [['foo', -5], ['foo', -5], ['bar', 5], ['bar', 10]],
 	leftAxis: {
 		labels: { anchor: 'end' },
 		range: { stepSize: 5 },
 		ticks: { length: 5, zeroth: true }
-	},
+	}
+});
+
+const group = createGroup({
+	divisorOperator: max,
+	groupSelector(input) { return input[0]; },
+	inputSeries: [['foo', -5], ['foo', -5], ['bar', 5], ['bar', 10]],
 	state: {
 		columnHeight: 150,
 		columnSpacing: 3,
@@ -129,7 +144,7 @@ const group = createGroupedColumnChart<string, [string, number]>({
 	valueSelector(input) { return input[1]; }
 });
 
-const stack = createStackedColumnChart<string, [string, number]>({
+const createStack: StackedColumnChartFactory<string, [string, number]> = createStackedColumnChart.extend({
 	bottomAxis: {
 		inputs: {
 			labelSelector({ input }) { return input; }
@@ -137,13 +152,16 @@ const stack = createStackedColumnChart<string, [string, number]>({
 		labels: { anchor: 'middle', textAnchor: 'end', rotation: -45, offset: -5 },
 		ticks: { anchor: 'end', length: 5, zeroth: true }
 	},
-	divisorOperator: max,
-	inputSeries: [['foo', -5], ['foo', -5], ['bar', 5], ['bar', 10], ['baz', -5], ['baz', 5]],
 	leftAxis: {
 		labels: { anchor: 'end' },
 		range: { stepSize: 5 },
 		ticks: { length: 5, zeroth: true }
-	},
+	}
+});
+
+const stack = createStack({
+	divisorOperator: max,
+	inputSeries: [['foo', -5], ['foo', -5], ['bar', 5], ['bar', 10], ['baz', -5], ['baz', 5]],
 	stackSelector(input) { return input[0]; },
 	state: {
 		columnHeight: 150,
@@ -157,7 +175,7 @@ const stack = createStackedColumnChart<string, [string, number]>({
 	valueSelector(input) { return input[1]; }
 });
 
-const stackDomain = createStackedColumnChart<string, [string, number]>({
+const createStackDomain: StackedColumnChartFactory<string, [string, number]> = createStackedColumnChart.extend({
 	bottomAxis: {
 		inputs: {
 			labelSelector({ input }) { return input; }
@@ -165,13 +183,16 @@ const stackDomain = createStackedColumnChart<string, [string, number]>({
 		labels: { anchor: 'middle', textAnchor: 'end', rotation: -45, offset: -5 },
 		ticks: { anchor: 'end', length: 5, zeroth: true }
 	},
-	divisorOperator: max,
-	inputSeries: [['foo', -5], ['foo', -5], ['bar', 5], ['bar', 10], ['baz', -5], ['baz', 5]],
 	leftAxis: {
 		labels: { anchor: 'end' },
 		range: { stepSize: 5 },
 		ticks: { length: 5, zeroth: true }
-	},
+	}
+});
+
+const stackDomain = createStackDomain({
+	divisorOperator: max,
+	inputSeries: [['foo', -5], ['foo', -5], ['bar', 5], ['bar', 10], ['baz', -5], ['baz', 5]],
 	stackSelector(input) { return input[0]; },
 	state: {
 		columnHeight: 150,

--- a/src/render/createColumnChart.ts
+++ b/src/render/createColumnChart.ts
@@ -4,7 +4,7 @@ import { h, VNode } from 'maquette';
 import { Datum } from '../data/interfaces';
 
 import createChart, { Chart, ChartOptions, ChartState } from './createChart';
-import createAxes, { Axes, AxesOptions } from './mixins/createAxesMixin';
+import createAxes, { Axes } from './mixins/createAxesMixin';
 import createColumnPlot, {
 	Column,
 	ColumnPoint,
@@ -24,7 +24,7 @@ export type ColumnChartOptions<
 	D extends Datum<any>,
 	// Extend ColumnChartState<T> since subclasses must still support the state properties of ColumnChart.
 	S extends ColumnChartState<T>
-> = ChartOptions<S> & ColumnPlotOptions<T, S> & AxesOptions<D>;
+> = ChartOptions<S> & ColumnPlotOptions<T, S>;
 
 export type ColumnChart<
 	T,


### PR DESCRIPTION
Remove options for configuring axes. Instead they need to be configured
on the prototype when extending a chart class.

This currently does not build: TypeScript fails to infer argument types
for the selector functions in the axes.

Also breaks the negative axes example.
